### PR TITLE
Add admin docs on port mappings

### DIFF
--- a/docs/administrator-docs/port-bindings.md
+++ b/docs/administrator-docs/port-bindings.md
@@ -1,0 +1,13 @@
+# Server port bindings
+
+This document aims to provide an admin with knowledge on what ports Jellyfin binds and what purpose they serve.
+
+### Static ports
+
+* 8096/tcp is used by default for HTTP traffic. This is admin configurable.
+* 8920/tcp is used by default for HTTPS traffic. This is admin configurable.
+* 1900/udp is used for service autodiscovery. This is _not_ admin configurable as it would break client autodiscover.
+
+### Dynamic ports
+
+* Completely random UDP port bind. It picks any UDP port that is unused on startup. It is used for specific LiveTV setups involving HD Homerun devices.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,12 @@ Have questions about how Jellyfin works or encountering an error? Check out the 
 * [Plugins](/user-docs/plugins): How to install plugins in Jellyfin.
 * [Full user documentation](/user-docs/index): The main user documentation page.
 
+## Administrator Documentation
+
+Want to know more about administering a Jellyfin server? Check out these pages!
+
+* [Port Bindings](/administrator-docs/port-bindings)
+
 ## Contributing to Jellyfin
 
 Want to help out? Check out the pages below for how to contribute.


### PR DESCRIPTION
Described what each is used for and if they are admin configurable or not.

Fixes issue #3 