### PR TITLE
Antennas plugin - Emby DVR support for Tvheadend Tuners

### DIFF
--- a/docs/user-docs/plugins.md
+++ b/docs/user-docs/plugins.md
@@ -14,6 +14,10 @@ Jellyfin has a collection of optional plugins that can be installed to provide a
 [![](https://img.shields.io/github/contributors/jellyfin/jellyfin-plugin-anime.svg)](https://github.com/jellyfin/jellyfin-plugin-anime)
 [![](https://img.shields.io/github/license/jellyfin/jellyfin-plugin-anime.svg)](https://github.com/jellyfin/jellyfin-plugin-anime)
 
+#### [antennas](https://github.com/TheJF/antennas)
+
+Takes your tuners in Tvheadend and emulates a HDHomeRun in order to connect to Emby's DVR feature. That means any tuner whether dvb-t, dvb-c, dvb-s or ATSC can work with Emby providing Tvheadend supports it (i.e you've installed the drivers for your tuner). It can be installed via binaries, Node or Docker. Set-up requires an anonymous user in Tvheadend with rights and streaming profiles as well as your channel list having the correct numbers. Configuration parameters are a URL that will show the status of Antennas, the URL of your Tvheadend installation with your username and password as well as the number of tuners you have. Then just setup your tuner in Emby by selecting a HD Homerun then enter your Antennas URL. For setting up guide data, you have to use XMLTV. Either a link or .xml file will work. In the UK, I use the free xmltv.co.uk which gives me a link for 7 days guide data.
+
 #### autoorganize
 
 [![](https://img.shields.io/github/languages/top/jellyfin/jellyfin-plugin-autoorganize.svg)](https://github.com/jellyfin/jellyfin-plugin-autoorganize)


### PR DESCRIPTION
Added link to Antennas which makes unsupported tuners that work in Tvheadend compatible with Emby DVR. Also wrote a quick guide to setting up Emby DVR. Included in the plugins section but happy to move it or make changes to the formatting as I've not used markdown before. 

[https://github.com/jellyfin/jellyfin/issues/40](https://github.com/jellyfin/jellyfin/issues/40)

Tested in jellyfin and streaming live tv and recording works.