### PR TITLE
Clean up the locations and organization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,9 +24,12 @@ Want to get starting using Jellyfin right now? Check out the pages below for how
 * [Arch Linux](https://aur.archlinux.org/packages/jellyfin/)
 * [Debian / Ubuntu](/user-docs/installing#debian-ubuntu)
 * [Docker](https://hub.docker.com/r/jellyfin/jellyfin)
-* [Windows](/user-docs/installing#windows-archives)
 * [unRaid](/user-docs/installing#unraid-docker)
 * [Kubernetes](/user-docs/installing#kubernetes)
+* [Windows](/user-docs/installing#windows-x64x86)
+* [MacOS](/user-docs/installing#macos)
+* [Generic Linux](/user-docs/installing#linux-generic-amd64)
+* [Portable Framework](/user-docs/installing#framework)
 
 Alternatively, Jellyfin may be built directly from the [source code](/user-docs/building).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ Want to get starting using Jellyfin right now? Check out the pages below for how
 * [Windows](/user-docs/installing#windows-x64x86)
 * [MacOS](/user-docs/installing#macos)
 * [Generic Linux](/user-docs/installing#linux-generic-amd64)
-* [Portable Framework](/user-docs/installing#framework)
+* [Portable DLL](/user-docs/installing#portable-dll)
 
 Alternatively, Jellyfin may be built directly from the [source code](/user-docs/building).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Note: Jellyfin is a fast moving project that is in its early stages, and this do
 
 ## Getting Started
 
-Want to get starting using Jellyfin right now? Check out the pages below for how to get Jellyfin installed on your machine.
+Want to get starting using Jellyfin right now? Check out the pages below for how to get Jellyfin [installed](/user-docs/installing) on your machine.
 
 * [Arch Linux](https://aur.archlinux.org/packages/jellyfin/)
 * [Debian / Ubuntu](/user-docs/installing#debian-ubuntu)

--- a/docs/user-docs/installing.md
+++ b/docs/user-docs/installing.md
@@ -44,9 +44,9 @@ MacOS builds in TAR archive format are available [here](https://repo.jellyfin.or
 
 Generic amd64 Linux builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/linux).
 
-### Framework
+### Portable DLL
 
-Platform-agnostic .NET Framework builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/portable). These builds use the binary `jellyfin.dll` and must be loaded with `dotnet`.
+Platform-agnostic .NET Core DLL builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/portable). These builds use the binary `jellyfin.dll` and must be loaded with `dotnet`.
 
 ## Arch AUR
 

--- a/docs/user-docs/installing.md
+++ b/docs/user-docs/installing.md
@@ -1,12 +1,16 @@
 # Installing Jellyfin from Binary Packages
 
-The Jellyfin project and its contributors offer a number of pre-built binary packages to assist in getting Jellyfin up and running quickly on multiple systems. If you are migrating from Emby, [check out our migration guide as well](/user-docs/migrate-from-emby).
+The Jellyfin project and its contributors offer a number of pre-built binary packages to assist in getting Jellyfin up and running quickly on multiple systems.
 
-## Docker Hub <a href="https://hub.docker.com/r/jellyfin/jellyfin"><img alt="Docker Pull Count" src="https://img.shields.io/docker/pulls/jellyfin/jellyfin.svg"></a>
+## Containers
+
+### Docker Hub
+
+<a href="https://hub.docker.com/r/jellyfin/jellyfin"><img alt="Docker Pull Count" src="https://img.shields.io/docker/pulls/jellyfin/jellyfin.svg"></a>
 
 The Jellyfin Docker image is available on [Docker Hub](https://hub.docker.com/r/jellyfin/jellyfin/).
 
-## Unraid Docker
+### Unraid Docker
 
 An Unraid Docker template is available in the repository.
 
@@ -19,14 +23,30 @@ An Unraid Docker template is available in the repository.
 
 1. Adjust any required paths and save.
 
-## Kubernetes
+### Kubernetes
 
 A community project to deploy Jellyfin on Kubernetes-based platforms exists at `https://github.com/home-cluster/jellyfin-openshift`.
 Any issues or feature requests related to deployment on Kubernetes-based platforms should be filed there.
 
-## Windows Archives
+## Portable Binaries
 
-Windows builds in ZIP archive format are available [here](https://repo.jellyfin.org/windows).
+Portable binary packages containing a compiled Jellyfin instance are available for multiple platforms.
+
+### Windows (x64/x86)
+
+Windows builds in ZIP archive format are available [here](https://repo.jellyfin.org/releases/server/windows).
+
+### MacOS
+
+MacOS builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/macos).
+
+### Linux (generic amd64)
+
+Generic amd64 Linux builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/linux).
+
+### Framework
+
+Platform-agnostic .NET Framework builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/windows). These builds use the binary `jellyfin.dll` and must be loaded with `dotnet`.
 
 ## Arch AUR
 
@@ -68,7 +88,7 @@ To restart the daemon, use:
 
 ### Packages
 
-Raw Debian packages, compatible with Debian 8+ or Ubuntu 14.04+, are available [here](https://repo.jellyfin.org/archive).
+Raw Debian packages, compatible with Debian 8+ or Ubuntu 14.04+, are available [here](https://repo.jellyfin.org/releases/server/debian).
 
 **NOTE:** When installing packages with `dpkg -i`, it won't attempt to resolve dependencies for you. Ensure you have `ffmpeg` installed already, or use `apt -f install` after attempting the `dpkg -i` to resolve and install the required dependencies.
 

--- a/docs/user-docs/installing.md
+++ b/docs/user-docs/installing.md
@@ -46,7 +46,7 @@ Generic amd64 Linux builds in TAR archive format are available [here](https://re
 
 ### Framework
 
-Platform-agnostic .NET Framework builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/windows). These builds use the binary `jellyfin.dll` and must be loaded with `dotnet`.
+Platform-agnostic .NET Framework builds in TAR archive format are available [here](https://repo.jellyfin.org/releases/server/portable). These builds use the binary `jellyfin.dll` and must be loaded with `dotnet`.
 
 ## Arch AUR
 

--- a/docs/user-docs/migrate-from-emby.md
+++ b/docs/user-docs/migrate-from-emby.md
@@ -1,6 +1,10 @@
 # Migrating from Emby to Jellyfin
 
-Jellyfin offers a seamless migration from Emby version 3.5.2 or earlier. Emby versions 3.5.3 or 3.6+ cannot be easily migrated, and we recommend rebuilding your library instead.
+NOTICE: Direct database migration from Emby (of any version) to Jellyfin is NOT SUPPORTED. We have found many subtle bugs due to the inconsistent database schemas that result from trying to do this, and strongly recommend that all Jellyfin users migrating from Emby start with a fresh database and library scan.
+
+The original procedure is provided below for reference however we cannot support it nor guarantee that a system upgraded in this way will work properly, if at all. If anyone is interested in writing a database migration script which will correct the deficiencies in the existing database and properly import them into Jellyfin, we would welcome it however!
+
+~~Jellyfin offers a seamless migration from Emby version 3.5.2 or earlier. Emby versions 3.5.3 or 3.6+ cannot be easily migrated, and we recommend rebuilding your library instead.~~
 
 Windows users may take advantage of the `install-jellyfin.ps1` script in the [Jellyfin repository](https://github.com/jellyfin/jellyfin) which includes an automatic upgrade option.
 


### PR DESCRIPTION
1. Add new builds to the list
2. Reorganize the headers to better group the various types
3. Use the new paths on the repo server
4. Remove link to migration instructions
5. Add big disclaimer to the migrations page about how it doesn't work