### PR TITLE
Add Ubuntu packages section

### DIFF
--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -51,13 +51,15 @@ Platform-agnostic .NET Core DLL builds in TAR archive format are available [here
 
 The Jellyfin package is in the AUR avilable [here](https://aur.archlinux.org/packages/jellyfin-git/).
 
-## Debian / Ubuntu
+## Debian
 
 ### Repository
 
-The Jellyfin team provides a Debian repository for installation on Debian and Ubuntu machines.
+The Jellyfin team provides a Debian repository for installation on Debian Jessie/Stretch/Buster.
 
-**NOTE:** Ubuntu users may find that the ffmpeg dependency package is not present in their release or is simply a rebranded `libav` which is not directly compatible. Please obtain the `ffmpeg` package directly from [their repository](https://ffmpeg.org/) to use Jellyfin on Ubuntu.
+1. If you are on Buster, remove any `ffmpeg` system packages as `4.1` is not compatible with Jellyfin at this time:
+    `sudo apt remove ffmpeg`
+    `sudo apt autoremove`
 
 **NOTE:** Only 64-bit (amd64) versions of Linux are supported as there is no Microsoft DotNET available for 32-bit (i386) Linux systems.
 
@@ -70,7 +72,7 @@ The Jellyfin team provides a Debian repository for installation on Debian and Ub
 1. Add a repository configuration at `/etc/apt/sources.list.d/jellyfin.list`, changing `<release>` to match your system:  
     `echo "deb [arch=amd64] https://repo.jellyfin.org/debian <release> main" | sudo tee /etc/apt/sources.list.d/jellyfin.list`
 
-    **NOTE:** Valid releases are: `jessie`, `stretch`, `buster`, and `ubuntu`. Ubuntu does not yet have different version releases.
+    **NOTE:** Valid releases are: `jessie`, `stretch`, and `buster`.
 
 1. Update APT repositories:  
     `sudo apt update`
@@ -85,18 +87,75 @@ The Jellyfin team provides a Debian repository for installation on Debian and Ub
 
 ### Packages
 
-Raw Debian packages, compatible with Debian 8+ or Ubuntu 14.04+, are available [here](https://repo.jellyfin.org/releases/server/debian).
+Raw Debian packages, compatible with Debian 8+, are available [here](https://repo.jellyfin.org/releases/server/debian).
 
 **Note:** The repository is the preferred way to obtain Jellyfin on Debian, as it contains several dependencies as well.
 
-1. Download the desired `.deb` package from the repository:  
-    `wget https://repo.jellyfin.org/releases/server/debian/jellyfin_latest_$(dpkg --print-architecture).deb`
+1. Download the desired `jellyfin` and `jellyfin-ffmpeg` `.deb` packages from the repository.
 
 1. Install the required dependencies:  
-    `sudo apt install ffmpeg at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.0.0`
+    `sudo apt install at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.0.0`
 
-1. Install the downloaded `.deb` package:  
-    `sudo dpkg -i jellyfin_latest_$(dpkg --print-architecture).deb`
+1. Install the downloaded `.deb` packages:  
+    `sudo dpkg -i jellyfin_*.deb jellyfin-ffmpeg_*.deb`
+
+1. Manage the Jellyfin system service with your tool of choice:  
+    `sudo service jellyfin status`  
+    `sudo systemctl restart jellyfin`  
+    `sudo /etc/init.d/jellyfin stop`  
+
+## Ubuntu
+
+### Migrating to the new repository
+
+Previous versions of Jellyfin included Ubuntu under the Debian repository. This has now been split out into its own repository to better handle the separate binary packages. If you encounter errors about the `ubuntu` release not being found and you previously configured an `ubuntu` `jellyfin.list` file, please follow these steps.
+
+1. Remove the old `/etc/apt/sources.list.d/jellyfin.list` file:  
+    `sudo rm /etc/apt/sources.list.d/jellyfin.list`
+
+1. Proceed with the following section as written.
+
+### Repository
+
+The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Trusty/Xenial/Bionic/Cosmic.
+
+**NOTE:** Ubuntu users may find that the ffmpeg dependency package is not present in their release or is simply a rebranded `libav` which is not directly compatible. Please obtain the `ffmpeg` `4.0.3` package directly from [their repository](https://ffmpeg.org/), or install `jellyfin-ffmpeg`, to use Jellyfin.
+
+1. Install HTTPS transport for APT if you haven't already:  
+    `sudo apt install apt-transport-https`
+
+1. Import the GPG signing key (signed by the Jellyfin Team):  
+    `wget -O - https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | sudo apt-key add -`
+
+1. Add a repository configuration at `/etc/apt/sources.list.d/jellyfin.list`, changing `<release>` to match your system:  
+    `echo "deb https://repo.jellyfin.org/ubuntu <release> main" | sudo tee /etc/apt/sources.list.d/jellyfin.list`
+
+    **NOTE:** Valid releases are: `trusty`, `xenial`, `bionic`, and `cosmic`.
+
+1. Update APT repositories:  
+    `sudo apt update`
+
+1. Install Jellyfin:  
+    `sudo apt install jellyfin`
+
+1. Manage the Jellyfin system service with your tool of choice:  
+    `sudo service jellyfin status`  
+    `sudo systemctl restart jellyfin`  
+    `sudo /etc/init.d/jellyfin stop`  
+
+### Packages
+
+Raw Ubuntu packages, compatible with Ubuntu 14.04+, are available [here](https://repo.jellyfin.org/releases/server/ubuntu).
+
+**Note:** The repository is the preferred way to obtain Jellyfin on Ubuntu, as it contains several dependencies as well.
+
+1. Download the desired `jellyfin` and `jellyfin-ffmpeg` `.deb` packages from the repository.
+
+1. Install the required dependencies:  
+    `sudo apt install at libsqlite3-0 libfontconfig1 libfreetype6 libssl1.0.0`
+
+1. Install the downloaded `.deb` packages:  
+    `sudo dpkg -i jellyfin_*.deb jellyfin-ffmpeg_*.deb`
 
 1. Manage the Jellyfin system service with your tool of choice:  
     `sudo service jellyfin status`  

--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -57,11 +57,11 @@ The Jellyfin package is in the AUR avilable [here](https://aur.archlinux.org/pac
 
 The Jellyfin team provides a Debian repository for installation on Debian Jessie/Stretch/Buster.
 
-1. If you are on Buster, remove any `ffmpeg` system packages as `4.1` is not compatible with Jellyfin at this time:
+**NOTE:** Only 64-bit (amd64) versions of Linux are supported as there is no Microsoft DotNET available for 32-bit (i386) Linux systems.
+
+1. If you are on Buster, remove any previous `ffmpeg` system packages as `4.1` is not compatible with Jellyfin at this time:
     `sudo apt remove ffmpeg`
     `sudo apt autoremove`
-
-**NOTE:** Only 64-bit (amd64) versions of Linux are supported as there is no Microsoft DotNET available for 32-bit (i386) Linux systems.
 
 1. Install HTTPS transport for APT if you haven't already:  
     `sudo apt install apt-transport-https`

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ Note: Jellyfin is a fast moving project that is in its early stages, and this do
 Want to get starting using Jellyfin right now? Check out the pages below for how to get Jellyfin [installed](/administrator-docs/installing) on your machine.
 
 * [Arch Linux](https://aur.archlinux.org/packages/jellyfin/)
-* [Debian / Ubuntu](/administrator-docs/installing#debian-ubuntu)
+* [Debian](/administrator-docs/installing#debian)
+* [Ubuntu](/administrator-docs/installing#ubuntu)
 * [Docker](https://hub.docker.com/r/jellyfin/jellyfin)
 * [unRaid](/administrator-docs/installing#unraid-docker)
 * [Kubernetes](/administrator-docs/installing#kubernetes)


### PR DESCRIPTION
Due to limitations of `reprepro`, I had to split out the Ubuntu repository from the Debian repository. This updates the installation docs (and index list) to reflect this by adding a new Ubuntu section with the relevant links changed.