### PR TITLE
Add links and sections for Fedora and CentOS

### DIFF
--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -51,6 +51,14 @@ Platform-agnostic .NET Core DLL builds in TAR archive format are available [here
 
 The Jellyfin package is in the AUR avilable [here](https://aur.archlinux.org/packages/jellyfin-git/).
 
+## Fedora
+
+Fedora 27 builds in RPM package format are available [here](https://repo.jellyfin.org/releases/server/fedora). Coming soon: an official Fedora repository.
+
+## CentOS
+
+CentOS/RHEL 7 builds in RPM package format are available [here](https://repo.jellyfin.org/releases/server/centos). Coming soon: an official CentOS/RHEL repository.
+
 ## Debian
 
 ### Repository

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ Want to get starting using Jellyfin right now? Check out the pages below for how
 * [Arch Linux](https://aur.archlinux.org/packages/jellyfin/)
 * [Debian](/administrator-docs/installing#debian)
 * [Ubuntu](/administrator-docs/installing#ubuntu)
+* [Fedora](/administrator-docs/installing#fedora)
+* [CentOS](/administrator-docs/installing#centos)
 * [Docker](https://hub.docker.com/r/jellyfin/jellyfin)
 * [unRaid](/administrator-docs/installing#unraid-docker)
 * [Kubernetes](/administrator-docs/installing#kubernetes)


### PR DESCRIPTION
These are official releases now and can be included.