### PR TITLE
Add link to kodi addon install guide

### DIFF
--- a/docs/user-docs/apps.md
+++ b/docs/user-docs/apps.md
@@ -108,7 +108,36 @@ The official Jellyfin Kodi plugin.
 **Links:**
 
 * [GitHub](https://github.com/jellyfin/jellyfin-kodi)
-* [Install Guide](https://github.com/jellyfin/jellyfin-kodi#install-jellyfin-for-kodi)
+
+#### Installing
+
+1. Download the add-on as a [zip file](https://github.com/jellyfin/jellyfin-kodi/archive/master.zip)
+    * It will be saved as `jellyfin-kodi-master.zip`
+2. Install Jellyfin for Kodi
+    * Navigate to "Add-on Browser"
+    * Select "Install from zip file"
+        * If prompted, enter settings and enable "Unknown Sources", then go back
+    * Select the newly downloaded file and it will be installed
+3. Within a few seconds you should be prompted for your server-details.
+    * If a Jellyfin server is detected on your local network, it will displayed in the popup
+    * If a Jellyfin server is not detected on your local network, select "Manually add server"
+        * Enter the server name or IP address and the port number (default is 8096)
+        * If using SSL and a reverse proxy, enter the full URL scheme in the "Host" field
+            * Host: https://jellyfin.example.com
+            * Port: 443
+    * Select user account and input password
+4. Once you're succesfully authenticated with the Jellyfin server, you'll be asked about your preferences for this device
+    * Select "Proceed" to continue setup now
+    * Choose your preferences for each option
+    * Select "Proceed" to configure libraries
+    * Select the libraries you would like to keep synced with this device
+5. The first sync of the Jellyfin server to the local Kodi database may take some time depending on your device and library size
+6. Once the full sync is done, you can browse your media in Kodi, and syncs will be done periodically in the background
+
+**Note: It's recommended to install the `Kodi Sync Queue` plugin into the Jellyfin server as well**
+
+This will help keep your media libraries up to date without waiting for a periodic resync from Kodi.
+
 
 ## Roku
 

--- a/docs/user-docs/apps.md
+++ b/docs/user-docs/apps.md
@@ -108,6 +108,7 @@ The official Jellyfin Kodi plugin.
 **Links:**
 
 * [GitHub](https://github.com/jellyfin/jellyfin-kodi)
+* [Install Guide](https://github.com/jellyfin/jellyfin-kodi#install-jellyfin-for-kodi)
 
 ## Roku
 


### PR DESCRIPTION
Adding a link to the install guide on the jellyfin-kodi repo.  Partner PR to the improvements to the install guide [here](https://github.com/jellyfin/jellyfin-kodi/pull/11)