### PR TITLE
Revised Docker instructions and installation link

### DIFF
--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -20,11 +20,23 @@ The Jellyfin Docker image is available on [Docker Hub](https://hub.docker.com/r/
     `--name jellyfin \`  
     `--volume /mnt/jellyfin_config:/config \`  
     `--volume /mnt/jellyfin_cache:/cache \`  
-    `--volume /path/to/media:/mnt/library \`  
-    `--publish 8096:8096 \`  
+    `--volume /path/to/media:/media:ro \`  
     `--net=host \`  
-    `jellyfin/jellyfin:latest`
-
+    `jellyfin/jellyfin:latest`  
+  
+Alternative docker-compose example:  
+```
+    version: "3"  
+    services:  
+        jellyfin:  
+          container_name: jellyfin  
+          image: jellyfin/jellyfin:latest  
+          network_mode: "host"  
+          volumes:  
+            - /mnt/jellyfin_config:/config  
+            - /mnt/jellyfin_cache:/cache  
+            - /path/to/media:/media:ro  
+```
 ### Unraid Docker
 
 An Unraid Docker template is available in the repository.

--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -17,7 +17,6 @@ The Jellyfin Docker image is available on [Docker Hub](https://hub.docker.com/r/
     `mkdir /path/to/cache`
 3. Start the server:  
     `docker run -d \`  
-    `--name jellyfin \`  
     `--volume /path/to/config:/config \`  
     `--volume /path/to/cache:/cache \`  
     `--volume /path/to/media:/media \`  
@@ -29,7 +28,6 @@ Alternative docker-compose example:
     version: "3"  
     services:  
         jellyfin:  
-          container_name: jellyfin  
           image: jellyfin/jellyfin  
           network_mode: "host"  
           volumes:  

--- a/docs/administrator-docs/installing.md
+++ b/docs/administrator-docs/installing.md
@@ -13,16 +13,16 @@ The Jellyfin Docker image is available on [Docker Hub](https://hub.docker.com/r/
 1. Get the latest image:  
     `docker pull jellyfin/jellyfin`
 2. Create directories on the host for persistent data storage:  
-    `mkdir /mnt/jellyfin_config`  
-    `mkdir /mnt/jellyfin_cache`
+    `mkdir /path/to/config`  
+    `mkdir /path/to/cache`
 3. Start the server:  
     `docker run -d \`  
     `--name jellyfin \`  
-    `--volume /mnt/jellyfin_config:/config \`  
-    `--volume /mnt/jellyfin_cache:/cache \`  
-    `--volume /path/to/media:/media:ro \`  
+    `--volume /path/to/config:/config \`  
+    `--volume /path/to/cache:/cache \`  
+    `--volume /path/to/media:/media \`  
     `--net=host \`  
-    `jellyfin/jellyfin:latest`  
+    `jellyfin/jellyfin`  
   
 Alternative docker-compose example:  
 ```
@@ -30,12 +30,12 @@ Alternative docker-compose example:
     services:  
         jellyfin:  
           container_name: jellyfin  
-          image: jellyfin/jellyfin:latest  
+          image: jellyfin/jellyfin  
           network_mode: "host"  
           volumes:  
-            - /mnt/jellyfin_config:/config  
-            - /mnt/jellyfin_cache:/cache  
-            - /path/to/media:/media:ro  
+            - /path/to/config:/config  
+            - /path/to/cache:/cache  
+            - /path/to/media:/media  
 ```
 ### Unraid Docker
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Want to get starting using Jellyfin right now? Check out the pages below for how
 * [Ubuntu](/administrator-docs/installing#ubuntu)
 * [Fedora](/administrator-docs/installing#fedora)
 * [CentOS](/administrator-docs/installing#centos)
-* [Docker](https://hub.docker.com/r/jellyfin/jellyfin)
+* [Docker](/administrator-docs/installing#docker-hub)
 * [unRaid](/administrator-docs/installing#unraid-docker)
 * [Kubernetes](/administrator-docs/installing#kubernetes)
 * [Windows](/administrator-docs/installing#windows-x64x86)


### PR DESCRIPTION
I've updated the homepage link to direct towards the installation instructions (rather than the Docker Hub page) as this caused some confusion on my part when initially looking for help.  This is now in line with how the other platform instructions are linked.

I've also updated the Docker instructions to use the proper mount points declared in the Dockerfile, as well as changed the media mount to a read-only bind.  

Finally, I've added a docker-compose example of deploying this container.