### PR TITLE
Reverse Proxy improvements

### DIFF
--- a/docs/administrator-docs/reverse-proxy.md
+++ b/docs/administrator-docs/reverse-proxy.md
@@ -4,47 +4,53 @@ It's possible to run Jellyfin behind another server acting as a reverse proxy.  
 
 Three popular options for reverse proxy systems are [Apache](https://httpd.apache.org/), [Haproxy](https://www.haproxy.com/), and [Nginx](https://www.nginx.com/).
 
+**Important:** In order for a reverse proxy to have the maximum benefit, you should have a publically routable IP address and a domain with DNS set up correctly.  These examples assume you want to run Jellyfin under a sub-domain (ie: jellyfin.example.com), but are easily adapted for the root domain if desired.
+
+When following this guide, be sure to replace the following variables with your information:
+
+  * `DOMAIN_NAME` - Your public domain name
+  * `SERVER_IP_ADDRESS` - The IP address of your Jellyfin server
+
+In addition, the examples are configured for use with LetsEncrypt certificates.  If you have a certificate from another source, change the ssl configuration from `/etc/letsencrypt/jellyfin.DOMAIN_NAME/` to the location of your certificate and key.
+
 ## Apache
 
 ```
 <VirtualHost *:80>
-    ServerAdmin master@jellyfin.example.com
-    ServerName jellyfin.example.com
+    ServerName jellyfin.DOMAIN_NAME
     
-    Redirect permanent / https://jellyfin.example.com
+    Redirect permanent / https://jellyfin.DOMAIN_NAME
     
-    ErrorLog /var/log/apache2/jellyfin.example.com-error.log
-    CustomLog /var/log/apache2/jellyfin.example.com-access.log combined
+    ErrorLog /var/log/apache2/jellyfin.DOMAIN_NAME-error.log
+    CustomLog /var/log/apache2/jellyfin.DOMAIN_NAME-access.log combined
 </VirtualHost>
 
 <IfModule mod_ssl.c>
 <VirtualHost *:443>
-    ServerAdmin master@jellyfin.example.com
-    ServerName jellyfin.example.com
+    ServerName jellyfin.DOMAIN_NAME
 
     ProxyPreserveHost On
 
-    ProxyPass "/embywebsocket" "ws://127.0.0.1:8096/embywebsocket"
-    ProxyPassReverse "/embywebsocket" "ws://127.0.0.1:8096/embywebsocket"
+    ProxyPass "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
+    ProxyPassReverse "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
 
-    ProxyPass "/" "http://127.0.0.1:8096/"
-    ProxyPassReverse "/" "http://127.0.0.1:8096/"
+    ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
+    ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
 
     SSLEngine on
-    SSLCertificateFile /etc/letsencrypt/jellyfin.example.com/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/jellyfin.example.com/privkey.pem
+    SSLCertificateFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/privkey.pem
     Protocols h2 http/1.1
 
-    ErrorLog /var/log/apache2/jellyfin.example.com-error.log
-    CustomLog /var/log/apache2/jellyfin.example.com-access.log combined
+    ErrorLog /var/log/apache2/jellyfin.DOMAIN_NAME-error.log
+    CustomLog /var/log/apache2/jellyfin.DOMAIN_NAME-access.log combined
 </VirtualHost>
 </IfModule>
 ```
 
 If you encouter errors, you may have to enable `mod_proxy` or `mod_ssl` support manually.
 ```
-$ sudo a2enmod proxy proxy_http
-$ sudo a2enmod ssl
+$ sudo a2enmod proxy proxy_http ssl
 ```
 
 ## Haproxy
@@ -54,17 +60,17 @@ frontend jellyfin_proxy
     bind *:80
 # Note that haproxy requires you to concatenate the certificate and key into a single file
 ## Note that if you're using haproxy 1.8+, you can enable http2 by swapping these lines
-##   bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.example.com/complete.pem alpn h2,http/1.1
-    bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.example.com/complete.pem
+##   bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/complete.pem alpn h2,http/1.1
+    bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/complete.pem
     redirect scheme https if !{ ssl_fc }
 
-    acl jellyfin_server hdr(host) -i jellyfin.example.com
+    acl jellyfin_server hdr(host) -i jellyfin.DOMAIN_NAME
     use_backend jellyfin if jellyfin_server
 
 backend jellyfin
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server jellyfin 127.0.0.1:8096
+    server jellyfin SERVER_IP_ADDRESS:8096
 ```
 
 ## Nginx
@@ -72,18 +78,18 @@ backend jellyfin
 ```
 server {
     listen 80;
-    server_name jellyfin.example.com;
+    server_name jellyfin.DOMAIN_NAME;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name jellyfin.example.com;
-    ssl_certificate /etc/letsencrypt/live/jellyfin.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/jellyfin.example.com/privkey.pem;
+    server_name jellyfin.DOMAIN_NAME;
+    ssl_certificate /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/privkey.pem;
 
     location / {
-        proxy_pass http://127.0.0.1:8096;
+        proxy_pass http://SERVER_IP_ADDRESS:8096;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;

--- a/docs/administrator-docs/reverse-proxy.md
+++ b/docs/administrator-docs/reverse-proxy.md
@@ -25,26 +25,29 @@ In addition, the examples are configured for use with LetsEncrypt certificates. 
     CustomLog /var/log/apache2/jellyfin.DOMAIN_NAME-access.log combined
 </VirtualHost>
 
-<IfModule mod_ssl.c>
-<VirtualHost *:443>
-    ServerName jellyfin.DOMAIN_NAME
-
-    ProxyPreserveHost On
-
-    ProxyPass "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
-    ProxyPassReverse "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
-
-    ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
-    ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
-
-    SSLEngine on
-    SSLCertificateFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/fullchain.pem
-    SSLCertificateKeyFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/privkey.pem
-    Protocols h2 http/1.1
-
-    ErrorLog /var/log/apache2/jellyfin.DOMAIN_NAME-error.log
-    CustomLog /var/log/apache2/jellyfin.DOMAIN_NAME-access.log combined
-</VirtualHost>
+# Uncomment this section after you have acquired a SSL Certificate
+# If you are not using a SSL certificate, replace the 'redirect'
+# line above with all lines below starting with 'Proxy'
+#<IfModule mod_ssl.c>
+#<VirtualHost *:443>
+#    ServerName jellyfin.DOMAIN_NAME
+#
+#    ProxyPreserveHost On
+#
+#    ProxyPass "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
+#    ProxyPassReverse "/embywebsocket" "ws://SERVER_IP_ADDRESS:8096/embywebsocket"
+#
+#    ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
+#    ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
+#
+#    SSLEngine on
+#    SSLCertificateFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/fullchain.pem
+#    SSLCertificateKeyFile /etc/letsencrypt/jellyfin.DOMAIN_NAME/privkey.pem
+#    Protocols h2 http/1.1
+#
+#    ErrorLog /var/log/apache2/jellyfin.DOMAIN_NAME-error.log
+#    CustomLog /var/log/apache2/jellyfin.DOMAIN_NAME-access.log combined
+#</VirtualHost>
 </IfModule>
 ```
 
@@ -59,10 +62,16 @@ $ sudo a2enmod proxy proxy_http ssl
 frontend jellyfin_proxy
     bind *:80
 # Note that haproxy requires you to concatenate the certificate and key into a single file
-## Note that if you're using haproxy 1.8+, you can enable http2 by swapping these lines
-##   bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/complete.pem alpn h2,http/1.1
-    bind *:443 ssl crt /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/complete.pem
-    redirect scheme https if !{ ssl_fc }
+# Uncomment the appropriate lines after you have acquired a SSL Certificate
+## Haproxy <1.7
+#    bind *:443 ssl crt /etc/ssl/jellyfin.DOMAIN_NAME.pem
+## Haproxy >1.8
+#    bind *:443 ssl crt /etc/ssl/jellyfin.DOMAIN_NAME.pem alpn h2,http/1.1
+#    redirect scheme https if !{ ssl_fc }
+
+# Uncomment these lines to allow LetsEncrypt authentication
+#    acl letsencrypt_auth path_beg /.well-known/acme-challenge/
+#    use_backend letsencrypt if letsencrypt_auth
 
     acl jellyfin_server hdr(host) -i jellyfin.DOMAIN_NAME
     use_backend jellyfin if jellyfin_server
@@ -71,6 +80,10 @@ backend jellyfin
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     server jellyfin SERVER_IP_ADDRESS:8096
+
+# Uncomment these lines to allow LetsEncrypt authentication
+#backend letsencrypt
+#    server letsencrypt 127.0.0.1:8888
 ```
 
 ## Nginx
@@ -82,25 +95,78 @@ server {
     return 301 https://$host$request_uri;
 }
 
-server {
-    listen 443 ssl http2;
-    server_name jellyfin.DOMAIN_NAME;
-    ssl_certificate /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/privkey.pem;
-
-    location / {
-        proxy_pass http://SERVER_IP_ADDRESS:8096;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Proto $remote_addr;
-        proxy_set_header X-Forwarded-Protocol $scheme;
-        proxy_redirect off;
-    
-        # Send websocket data to the backend aswell
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-}
+# Uncomment this section after you have acquired a SSL Certificate
+# If you are not using a SSL certificate, replace the 'return 301'
+# line above with the location block from the section below
+#server {
+#    listen 443 ssl http2;
+#    server_name jellyfin.DOMAIN_NAME;
+#    ssl_certificate /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/fullchain.pem;
+#    ssl_certificate_key /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/privkey.pem;
+#
+#    location / {
+#        proxy_pass http://SERVER_IP_ADDRESS:8096;
+#        proxy_set_header X-Real-IP $remote_addr;
+#        proxy_set_header X-Forwarded-for $proxy_add_x_forwarded_for;
+#        proxy_set_header Host $host;
+#        proxy_set_header X-Forwarded-Proto $remote_addr;
+#        proxy_set_header X-Forwarded-Protocol $scheme;
+#        proxy_redirect off;
+#    
+#        # Send websocket data to the backend aswell
+#        proxy_http_version 1.1;
+#        proxy_set_header Upgrade $http_upgrade;
+#        proxy_set_header Connection "upgrade";
+#    }
+#}
 ```
+
+## LetsEncrypt with Certbot
+
+LetsEncrypt is a service that provides free SSL/TLS certificates to users.  Certbot is a client that makes this easy to accomplish and automate.  In addition, it has plugins for Apache and Nginx that make automating certificate generation even easier.
+
+Installation instructions for most Linux distributions can be found on the [Certbot website](https://certbot.eff.org/docs/install.html#operating-system-packages).
+
+Once the packages are installed, you're ready to generate a new certificate.
+
+### Apache
+
+After installing certbot and the Apache plugin, certificate generation is accomplished by:
+
+`certbot certonly --apache --noninteractive --agree-tos --email YOUR_EMAIL -d jellyfin.DOMAIN_NAME`
+
+Update the 'SSLCertificateFile' and 'SSLCertificateKeyFile' sections, then restart the service.
+
+Add a job to cron so the certificate will be renwed automatically:
+
+`echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload apache2'" | sudo tee -a /etc/cron.d/renew_certbot`
+
+### Haproxy
+
+Haproxy doesn't currently have a certbot plugin.  To get around this, run certbot in standalone mode and proxy traffic back to it.  Enable the frontend and backend in the config above, and then run:
+
+`certbot certonly --standalone --preferred-challenges http-01 --http-01-port 8888 --noninteractive --agree-tos --email YOUR_EMAIL -d jellyfin.DOMAIN_NAME`
+
+The port can be changed to anything you like, but be sure that the haproxy config and your certbot command match.
+
+Haproxy needs to have the certificate and key files concatenated into the same file to read it correctly.  This can be accomplished with the following command.
+
+`cat /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/fullchain.pem /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/privkey.pem > /etc/ssl/jellyfin.DOMAIN_NAME.pem`
+
+Uncomment the appropriate 'bind *:443' and the redirect section in the config, then restart the service.
+
+Add a job to cron so the certificate will be renwed automatically:
+
+`echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'cat /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/fullchain.pem /etc/letsencrypt/live/jellyfin.DOMAIN_NAME/privkey.pem > /etc/ssl/jellyfin.DOMAIN_NAME.pem && systemctl reload haproxy'" | sudo tee -a /etc/cron.d/renew_certbot`
+
+### Nginx
+
+After installing certbot and the Nginx plugin, certificate generation is accomplished by:
+
+`certbot certonly --nginx --noninteractive --agree-tos --email YOUR_EMAIL -d jellyfin.DOMAIN_NAME`
+
+Uncomment the SSL server block in the config and update the 'ssl_certificate' and 'ssl_certificate_key' fields, then restart the service.
+
+Add a job to cron so the certificate will be renwed automatically:
+
+`echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload nginx'" | sudo tee -a /etc/cron.d/renew_certbot`


### PR DESCRIPTION
Added some notes about prerequisites and changed the server blocks to have a more generic format (`IP_ADDRESS` instead of `127.0.0.1`, same with server names).  Mostly following through on suggestions from #48.

Also added notes about LetsEncrypt and Certbot for each of the proxy systems that should close https://github.com/jellyfin/jellyfin-docs/issues/45.  Could use some discussion here, based on different people's opinions.  I've tested all three and was able to get new certificates, but they could probably get cleaned up further.
* I'm suggesting using the Apache and Nginx plugins to certbot instead of the standalone method [mentioned before](https://github.com/jellyfin/jellyfin-docs/pull/40#issuecomment-464976746). Both because it's a little easier on the end user, and because trying to proxypass from Apache to the certbot standalone port was frustrating me.  Still using the standalone method for haproxy, but that one works smoothly.
* Explicitly stating things that won't work without an ssl cert, as opposed to giving the full code blocks that won't let the service start right off the bat (Apache and Nginx won't start with a SSL server block with no certificates available).
* Could use opinions on the server blocks themselves.  At this moment, the example server block is enough to get a SSL certificate, but not reach JF immediately over plain http.  But if we add support for http in, the blocks are going to get a good bit longer and require more explanation about what to change after a certificate has come into play.

I'm not particularly thrilled about giving out server blocks that can't actually reach JF right away, but i'm also not thrilled about longer and more complicated instructions of how to switch.  Formatting suggestions are welcome.

One idea is to structure the page like:
```
http:
  apache:
  haproxy:
  nginx:
letsencrypt:
  apache:
  haproxy:
  nginx:
https:
  apache:
  haproxy:
  nginx:
```