### PR TITLE
Add instructions to run jellyfin from source

### DIFF
--- a/docs/administrator-docs/building.md
+++ b/docs/administrator-docs/building.md
@@ -31,6 +31,8 @@ All package builds begin with the first two steps:
     `./build --list-platforms`
     `./build <platform> all`
 
+4. The resulting archives can be found at `../bin/<platform>`
+
 **NOTE:** This will very likely be split out into a separate repository at some point in the future.
 
 ## Windows on Windows


### PR DESCRIPTION
I'm not used to dotnet core so it took me some time to understand how to run it after building it from source.

Adds an instruction to the list to run it.