### PR TITLE
Fix broken reverse proxy link in quick-start.md

### DIFF
--- a/docs/administrator-docs/quick-start.md
+++ b/docs/administrator-docs/quick-start.md
@@ -8,7 +8,7 @@
 
 4. Secure the server with a method of your choice.
   * Create an SSL certificate and add it on the **Networking** page.
-  * Put your server behind a [reverse proxy](adminitrator-docs/reverse-proxy).
+  * Put your server behind a [reverse proxy](/administrator-docs/reverse-proxy).
   * Only allow local connections and refrain from forwarding any ports.
 
 5. Enjoy your media.


### PR DESCRIPTION
Missing s and /, breaking link.