### PR TITLE
Disable buffer on nginx to reduce streaming load

### DIFF
--- a/docs/administrator-docs/reverse-proxy.md
+++ b/docs/administrator-docs/reverse-proxy.md
@@ -113,6 +113,9 @@ server {
 #        proxy_set_header X-Forwarded-Proto $scheme;
 #        proxy_set_header X-Forwarded-Protocol $scheme;
 #        proxy_set_header X-Forwarded-Host $http_host;
+#
+#        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+#        proxy_buffering off;
 #    }
 #    location /embywebsocket {
 #        # Proxy Jellyfin Websockets traffic


### PR DESCRIPTION
Without this nginx will buffer everything making it unresponsive and bringing all local vhosts down.
Maybe optional only disable the buffer on a specified location, but this works best for me.