### PR TITLE
Add mopidy plugin to the list of clients

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -161,6 +161,18 @@ The official Jellyfin Kodi plugin.
 
 This will help keep your media libraries up to date without waiting for a periodic resync from Kodi.
 
+## Mopidy
+
+### Mopidy-Jellyfin
+
+A third party plugin for Mopidy that uses Jellyfin as a backend.
+
+**Status:** ⭐ Active, 3rd-party
+
+**Links:**
+
+* [GitHub](https://github.com/mcarlton00/mopidy-jellyfin)
+
 ## Roku
 
 ### Jellyfin for Roku


### PR DESCRIPTION
Adds a section to the client page linking to https://github.com/mcarlton00/mopidy-jellyfin