### PR TITLE
Move Traefik out from under Certbot

### DIFF
--- a/docs/administrator-docs/reverse-proxy.md
+++ b/docs/administrator-docs/reverse-proxy.md
@@ -296,7 +296,7 @@ Add a job to cron so the certificate will be renwed automatically:
 
 `echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload nginx'" | sudo tee -a /etc/cron.d/renew_certbot`
 
-### Traefik (with docker-compose)
+## Traefik (with docker-compose)
 
 Traefik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy. Traefik integrates with your existing infrastructure components (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, ...) and configures itself automatically and dynamically. Pointing Traefik at your orchestrator should be the only configuration step you need. (https://traefik.io/)
 


### PR DESCRIPTION
Traefik should have it's own heading in the sidebar