### PR TITLE
Change windows build title/powershell command/slashes

### DIFF
--- a/docs/administrator-docs/building.md
+++ b/docs/administrator-docs/building.md
@@ -35,14 +35,15 @@ All package builds begin with the first two steps:
 
 **NOTE:** This will very likely be split out into a separate repository at some point in the future.
 
-## Windows on Windows
+## Build script on Windows
 
 3. Install the dotnet core SDK 2.2 from [Microsoft's Webpage](https://dotnet.microsoft.com/download/dotnet-core/2.2) and [install Git for Windows](https://gitforwindows.org/). You must be on Powershell version 3 or higher.
 
-4. Set `executionpolicy` to unrestricted.
+4. From Powershell set the execution policy to unrestricted:    
+`set-executionpolicy unrestricted`
 
 5. Run the Jellyfin build script:  
-    `deployment/windows/build-jellyfin.ps1 -verbose`
+    `deployment\windows\build-jellyfin.ps1 -verbose`
 
     * The `-WindowsVersion` and `-Architecture` flags can optimize the build for your current environment; the default is generic Windows x64.
 

--- a/docs/administrator-docs/connectivity.md
+++ b/docs/administrator-docs/connectivity.md
@@ -2,15 +2,15 @@
 
 ### Connect
 
-Many clients will automatically discover servers running on the same LAN and display them on login. If you are outside the network when you connect you can simply type in the complete IP address or domain name in the server field with the correct port to continue to the login page. You can find the default ports below to access the web frontend.
+Many clients will automatically discover servers running on the same LAN and display them on login. If you are outside the network when you connect you can type in the complete IP address or domain name in the server field with the correct port to continue to the login page. You can find the default ports below to access the web frontend.
 
 ### Troubleshooting
 
-If you can access the web interface over HTTP but not HTTPS then you likely have an error with the certificate. Jellyfin uses a PFX file to handle HTTPS traffic. If you created the file with a password then you will have to enter that value on the **Networking** page in the settings.
+If you can access the web interface over HTTP but not HTTPS, then you likely have an error with the certificate. Jellyfin uses a PFX file to handle HTTPS traffic. If you created the file with a password, then you will have to enter that value on the **Networking** page in the settings.
 
-If you can access the server locally but not outside of your LAN then you likely have an issue with the router configuration. Please see the [port forwarding](/administrator-docs/port-forwarding) for more information.
+If you can access the server locally but not outside of your LAN, then you likely have an issue with the router configuration. Please see the [port forwarding](/administrator-docs/port-forwarding) for more information.
 
-The easiest way to check for issues is checking the logs, which can be accessed through the settings on the web frontend or in the log directory on your server. If there are no logs at all relating to web traffic, even over a LAN connection, then the server hasn't been reached at all yet. This would indicate either an incorrect addess or an issue somewhere else on the network.
+The easiest way to check for issues is by checking the logs, which can be accessed through the settings on the web frontend or in the log directory on your server. If there are no logs at all relating to web traffic, even over a LAN connection, then the server hasn't been reached at all yet. This would indicate either an incorrect address or an issue somewhere else on the network.
 
 ### Static Ports
 
@@ -24,7 +24,7 @@ This setting can also be modified from the **Networking** page to use a differen
 
 **Service Discovery:** 1900
 
-Since client auto-discover would break if this option was configurable, you cannot change this in the settings at this time.
+Since client auto-discover would break if this option were configurable, you cannot change this in the settings at this time.
 
 ### Dynamic Ports
 


### PR DESCRIPTION
Updated windows build script title for consistency.

Added explicit powershell command to step 4 in windows
build steps.

Changed slashes to match windows directory scheme in
step 5.