### PR TITLE
Made GitHub Releases trigger on BuildCompletion, added update submodules command and add publish script for VPS.

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -17,6 +17,12 @@ jobs:
       submodules: true
       persistCredentials: true
 
+    - task: CmdLine@2
+      displayName: "Update submodules"
+      inputs:
+        script: 'git submodule update --recursive --remote'
+        workingDirectory: '$(Build.SourcesDirectory)'
+
     - task: PowerShell@2
       displayName: "DocFX Build"
       inputs:
@@ -25,7 +31,7 @@ jobs:
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: ArchiveFiles@2
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
       displayName: "Package Documentation Website"
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)/_site'
@@ -38,7 +44,7 @@ jobs:
         #quiet: # Optional
 
     - task: GitHubRelease@0
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
       displayName: "Create GitHub release"
       inputs:
         gitHubConnection: Jellyfin Release Download

--- a/.ci/publish-to-gh-pages.sh
+++ b/.ci/publish-to-gh-pages.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Download the latest release.
+curl -s https://api.github.com/repos/jellyfin/jellyfin-docs/releases/latest | grep "browser_download_url.*docs-.*\.tar\.gz" | cut -d : -f 2,3 | tr -d \" | wget -O /tmp/docs.tar.gz -qi -
+# Clean any old files
+rm -rf docs/
+
+mkdir -p docs/
+pushd docs
+# Extract the files
+tar -xzf /tmp/docs.tar.gz
+popd
+git add docs/
+git commit -m "CI Documentation update"
+git push origin


### PR DESCRIPTION
As you can see, the builds do trigger correctly, but skip the GitHub Release: https://dev.azure.com/jellyfin-project/jellyfin/_build/results?buildId=783

Also it does not update the submodule to latest master.

Added VPS script to be run inside `jellyfin.github.io` repo (with write access and setup as jellyfin-bot)
```sh
#!/bin/bash

# Download the latest release.
curl -s https://api.github.com/repos/jellyfin/jellyfin-docs/releases/latest | grep "browser_download_url.*docs-.*\.tar\.gz" | cut -d : -f 2,3 | tr -d \" | wget -O /tmp/docs.tar.gz -qi -
# Clean any old files
rm -rf docs/

mkdir -p docs/
pushd docs
# Extract the files
tar -xzf /tmp/docs.tar.gz
popd
git add docs/
git commit -m "CI Documentation update"
git push origin
```