### PR TITLE
Update Kodi info about unicode support

### DIFF
--- a/general/clients/clients.md
+++ b/general/clients/clients.md
@@ -177,8 +177,6 @@ This will help keep your media libraries up to date without waiting for a period
 
 **Note: Kodi's default skin does not display all unicode characters. To display unicode characters the skins font must be changed**
 
-
-
 ## Mopidy
 
 ### Mopidy-Jellyfin

--- a/general/clients/clients.md
+++ b/general/clients/clients.md
@@ -175,6 +175,10 @@ The official Jellyfin Kodi plugin.
 
 This will help keep your media libraries up to date without waiting for a periodic resync from Kodi.
 
+**Note: Kodi's default skin does not display all unicode characters. To display unicode characters the skins font must be changed**
+
+
+
 ## Mopidy
 
 ### Mopidy-Jellyfin


### PR DESCRIPTION
Kodi's default skins font does not support displaying all of unicode. The next version of the addon will support these characters thus the font has to be changed to display them properly 