### PR TITLE
Rename and remove rooms

### DIFF
--- a/general/getting-help.md
+++ b/general/getting-help.md
@@ -26,8 +26,7 @@ We are also active on social media:
 * <a href="https://matrix.to/#/#jellyfin-announce:matrix.org"><img alt="jellyfin-announce" src="https://img.shields.io/matrix/jellyfin-announce:matrix.org.svg?logo=matrix&label=jellyfin-announce"></a>: Announcements for releases and other important information
 * <a href="https://matrix.to/#/#jellyfin-troubleshooting:matrix.org"><img alt="jellyfin-troubleshooting" src="https://img.shields.io/matrix/jellyfin-troubleshooting:matrix.org.svg?logo=matrix&label=jellyfin-troubleshooting"></a>: User troubleshooting
 * <a href="https://matrix.to/#/#jellyfin-dev:matrix.org"><img alt="jellyfin-dev" src="https://img.shields.io/matrix/jellyfin-dev:matrix.org.svg?logo=matrix&label=jellyfin-dev"></a>: Main room for development communication
-* <a href="https://matrix.to/#/#jellyfin-web-dev:matrix.org"><img alt="jellyfin-web-dev" src="https://img.shields.io/matrix/jellyfin-web-dev:matrix.org.svg?logo=matrix&label=jellyfin-web-dev"></a>: Web development
-* <a href="https://matrix.to/#/#jellyfin-app-dev:matrix.org"><img alt="jellyfin-app-dev" src="https://img.shields.io/matrix/jellyfin-app-dev:matrix.org.svg?logo=matrix&label=jellyfin-app-dev"></a>: Client development
+* <a href="https://matrix.to/#/#jellyfin-app-dev:matrix.org"><img alt="jellyfin-dev-client" src="https://img.shields.io/matrix/jellyfin-app-dev:matrix.org.svg?logo=matrix&label=jellyfin-dev-client"></a>: Client and Web development
 * <a href="https://matrix.to/#/#jellyfin-offtopic:matrix.org"><img alt="jellyfin-offtopic" src="https://img.shields.io/matrix/jellyfin-offtopic:matrix.org.svg?logo=matrix&label=jellyfin-offtopic"></a>: Chat about anything
 
 ## IRC Channels


### PR DESCRIPTION
Removes web-dev, which is being deprecated in favour of a unified dev-client room.