### PR TITLE
Add Security headers to Nginx remote proxy configuration.

### DIFF
--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -121,6 +121,14 @@ server {
 #    ssl_stapling on;
 #    ssl_stapling_verify on;
 #
+#    # Security / XSS Mitigation Headers
+#    add_header X-Frame-Options "SAMEORIGIN";
+#    add_header X-XSS-Protection "1; mode=block";
+#
+#    # Content Security Policy
+#    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+#    add_header Content-Security-Policy "default-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data:; media-src *; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js blob:; object-src 'none'; connect-src 'self'";
+#
 #    location / {
 #        # Proxy main Jellyfin traffic
 #        proxy_pass http://SERVER_IP_ADDRESS:8096;

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -127,7 +127,7 @@ server {
 #
 #    # Content Security Policy
 #    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-#    add_header Content-Security-Policy "default-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data:; media-src *; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js blob:; object-src 'none'; connect-src 'self'";
+#    add_header Content-Security-Policy "default-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src * data:; media-src * data:; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js blob:; object-src 'none'; connect-src 'self'";
 #
 #    location / {
 #        # Proxy main Jellyfin traffic


### PR DESCRIPTION
This commit adds the security headers for the example configuration of the nginx Reverse proxy for jellyfin-web. Related to https://github.com/jellyfin/jellyfin/issues/1885 https://github.com/jellyfin/jellyfin/issues/879

X-Frame-Options and X-XSS-Protection carry near-zero risk of breakage, however the Content Security Policy (CSP) has to be sufficiently relaxed as to not block functionality.

I would in particular prefer to remove 'unsafe-inline' for script-src and use sha hash for chromecast script, however inline scripts would trigger CSP blocking (seems to be mostly in the form of onclick() elements)

Additionally, by including a hash for the chromecast js 'unsafe-inline' is disabled so that is being left out of the CSP.

I'm not aware of any additional external js aside from the chromecast js, but by restricting script-src to 'self' external js needs to be explicitly included into the CSP.