### PR TITLE
Add security headers to Nginx reverse proxy

### DIFF
--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -121,6 +121,15 @@ server {
 #    ssl_stapling on;
 #    ssl_stapling_verify on;
 #
+#    # Security / XSS Mitigation Headers
+#    add_header X-Frame-Options "SAMEORIGIN";
+#    add_header X-XSS-Protection "1; mode=block";
+#    add_header X-Content-Type-Options "nosniff";
+#
+#    # Content Security Policy
+#    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+#    add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js; worker-src 'self' blob:; connect-src 'self'; object-src 'none'";
+#
 #    location / {
 #        # Proxy main Jellyfin traffic
 #        proxy_pass http://SERVER_IP_ADDRESS:8096;

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -128,7 +128,9 @@ server {
 #
 #    # Content Security Policy
 #    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-#    add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js; worker-src 'self' blob:; connect-src 'self'; object-src 'none'";
+#    # Enforces https content and restricts JS/CSS to origin
+#    # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
+#    add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 #
 #    location / {
 #        # Proxy main Jellyfin traffic


### PR DESCRIPTION
This commit adds the security headers for the example configuration of the nginx reverse proxy for jellyfin-web. Related to jellyfin/jellyfin#1885 jellyfin/jellyfin#879

X-Frame-Options, X-Content-Type-Options, and X-XSS-Protection carry near-zero risk of breakage, however the Content Security Policy (CSP) has to be sufficiently relaxed as to not block functionality.

I'm not aware of any additional external js aside from the chromecast js, but by restricting script-src to 'self' external js needs to be explicitly included into the CSP.

I would in prefer to remove 'unsafe-inline' for script-src and use a sha hash for chromecast script, however inline scripts would trigger CSP blocking (seems to be mostly in the form of onclick() elements)

Additionally, by including a hash for the chromecast js 'unsafe-inline' is disabled so that is being left out of the CSP.

