### PR TITLE
Update to traefik

### DIFF
--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -449,7 +449,9 @@ Congratulation, your RP is UP !
 
 For Jellyfin, just launch your Jellyfin server with this docker-compose `docker-compose up -d`.
 
-Note you must change the ${JELLYFIN_DOMAIN} for your domain, like jellyfin.mydomain.xyz for example. If using an HDHomeRun, use network_mode: host, remove the traefik network information for proper building of the yaml.
+Note: you must change the ${JELLYFIN_DOMAIN} for your domain, like jellyfin.mydomain.xyz for example. If using an HDHomeRun, use network_mode: host, remove the traefik network information for proper building of the yaml. 
+
+Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in traefik, you cannot dynamically route to containers, you must set a static route in your toml/file.
 
 ```
 
@@ -504,8 +506,50 @@ networks:
 
 ```
 
-Go to jellyfin.mysite.xyz (in this case), and your jellyfin is UP with HTTPS (AES 256).
+Here's an example of a static route.
+```
+[backends]
+  [backends.jellyfin]
+    [backends.jellyfin.servers]
+      [backends.jellyfin.servers.server-jellyfin-ext]
+        url = "http://192.168.1.100:8086"
+		weight = 10
+
+  [frontends.jellyfin]
+    backend = "jellyfin"
+    passHostHeader = true
+	priority = 1
+#	basicAuth = [
+#      "username:pas$worde$capedwithnoextra$",
+#    ]
+#      [traefik.frontend.jellyfin.auth.basic.usersFile]
+#        usersFile = "/.htpasswd"
+#      [frontends.jellyfin.auth]
+#        headerField = "X-WebAuth-User"
+#        [frontends.cockpit.auth.forward]
+#          address = "http://oauth:4181"
+#          trustForwardHeader = true
+#          authResponseHeaders = ["X-Auth-User"]
+      [frontends.jellyfin.routes]
+        [frontends.jellyfin.routes.route-jellyfin-ext]
+          rule = "Host:jellyfin.domain.com;"
+      [frontends.jellyfin.headers]
+        SSLRedirect = true
+        SSLHost = "jellyfin.domain.com"
+        SSLForceHost = true
+        STSSeconds = 315360000
+        STSIncludeSubdomains = true
+        STSPreload = true
+        forceSTSHeader = true
+        frameDeny = false
+        contentTypeNosniff = true
+        browserXSSFilter = true
+```
+
+
+Go to jellyfin.domain.com (in this case), and your jellyfin is UP with HTTPS (AES 256).
 
 # Final steps
 
 It's strongly recommend that you check your SSL strength and server security at [SSLLabs](https://www.ssllabs.com/ssltest/analyze.html)
+

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -441,7 +441,7 @@ network = "traefik_network_name"
 
 Finally, create an empty acme.json : `touch acme.json` `chmod 600 acme.json` 
 
-IMPORTANT ! Change domain.tld by your domain / subdomain name, and change the mail of the acme (user@example.com in traefik.toml). Let's Encrypt does not require a valid email address however example.com will be flagged as not a proper email address.
+IMPORTANT ! Change domain.tld by your domain / subdomain name, and change the mail of the acme (user@example.com in traefik.toml). Let's Encrypt does not require a valid email address however example.com will be flagged as not being a proper email address.
 
 Launch Traefik : `docker-compose up -d`
 
@@ -451,7 +451,7 @@ For Jellyfin, just launch your Jellyfin server with this docker-compose `docker-
 
 Note: you must change the ${JELLYFIN_DOMAIN} for your domain, like jellyfin.mydomain.xyz for example. If using an HDHomeRun, use network_mode: host, remove the traefik network information for proper building of the yaml. 
 
-Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in traefik, you cannot dynamically route to containers, you must set a static route in your toml/file.
+Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in traefik, you cannot dynamically route to containers in host_mode, you must set a static route in your toml/file.
 
 ```
 
@@ -472,12 +472,6 @@ services:
       - /path/to/data:/share:rw
       - ./conf:/config:rw
       - /etc/localtime:/etc/localtime:ro
-    environment:
-      APP_UID: 1000
-      APP_UID: 1000
-      TZ: Europe/Paris
-      UMASK_SET: 022
-      GIDLIST=100 #A comma-separated list of additional GIDs to run emby as (default 2)#
     labels:
       traefik.enable: "true"
       traefik.backend: jellyfin
@@ -506,7 +500,8 @@ networks:
 
 ```
 
-Here's an example of a static route.
+Here's an example of a static route. If a static route is used, disable or remove the traefik labels  and remove the ports from your compose file.
+
 ```
 [backends]
   [backends.jellyfin]
@@ -519,17 +514,6 @@ Here's an example of a static route.
     backend = "jellyfin"
     passHostHeader = true
 	priority = 1
-#	basicAuth = [
-#      "username:pas$worde$capedwithnoextra$",
-#    ]
-#      [traefik.frontend.jellyfin.auth.basic.usersFile]
-#        usersFile = "/.htpasswd"
-#      [frontends.jellyfin.auth]
-#        headerField = "X-WebAuth-User"
-#        [frontends.cockpit.auth.forward]
-#          address = "http://oauth:4181"
-#          trustForwardHeader = true
-#          authResponseHeaders = ["X-Auth-User"]
       [frontends.jellyfin.routes]
         [frontends.jellyfin.routes.route-jellyfin-ext]
           rule = "Host:jellyfin.domain.com;"

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -330,7 +330,7 @@ services:
   traefik:
     container_name: traefik
     hostname: traefik
-    image: traefik:traefik:v1.7.19
+    image: traefik:v1.7.19
     networks:
       - traefik
     ports:
@@ -364,7 +364,6 @@ services:
 
 networks:
   traefik:
-    external: true
 ```
 
  For security, add a password to the traefik interface (DOMAIN_OF_THE_WEB_ADMIN_INTERFACE, traefik.mysite.com for exemple) :
@@ -495,12 +494,9 @@ services:
 
 networks:
   traefik:
-    external: true
-
-
 ```
 
-Here's an example of a static route. If a static route is used, disable or remove the traefik labels  and remove the ports from your compose file.
+Here's an example of a static backend. If a static backend is used, disable or remove the traefik labels and ports from your compose file.
 
 ```
 [backends]
@@ -510,6 +506,7 @@ Here's an example of a static route. If a static route is used, disable or remov
         url = "http://192.168.1.100:8086"
 		weight = 10
 
+[frontends]
   [frontends.jellyfin]
     backend = "jellyfin"
     passHostHeader = true

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -451,7 +451,7 @@ For Jellyfin, just launch your Jellyfin server with this docker-compose `docker-
 
 Note: you must change the ${JELLYFIN_DOMAIN} for your domain, like jellyfin.mydomain.xyz for example. If using an HDHomeRun, use network_mode: host, remove the traefik network information for proper building of the yaml. 
 
-Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in traefik, you cannot dynamically route to containers in host_mode, you must set a static route in your toml/file.
+Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in traefik, you cannot dynamically route to containers in host_mode, you must set a static route in your toml/file. Using host_mode is required to use DLNA or an HdHomeRun.
 
 ```
 


### PR DESCRIPTION
Due to the bug in traefik, a static route must be set in order to use network_mode: host in the yml. This should fix a lot of issues for people who want DLNA, HDHomeRun and FQDN together.

https://github.com/containous/traefik/issues/5559