### PR TITLE
Add flag to make Docker autostart Jellyfin

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -27,6 +27,7 @@ The Jellyfin Docker image is available on [Docker Hub](https://hub.docker.com/r/
     `--volume /path/to/cache:/cache \`  
     `--volume /path/to/media:/media \`  
     `--net=host \`  
+    `--restart=unless-stopped \`  
     `jellyfin/jellyfin`  
   
 Alternatively, using docker-compose:  


### PR DESCRIPTION
Considering other installations of Jellyfin contain services to autostart Jellyfin, the `--restart=unless-stopped` command on Docker will run Jellyfin each time the Docker service is started (e.g. upon startup or reboot). I imagine this would be the desired behavior for almost all Jellyfin installations.