### PR TITLE
Fix DLNA and HDHR for Traefik Docker compose

### DIFF
--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -15,7 +15,7 @@ Some popular options for reverse proxy systems are [Apache](https://httpd.apache
 When following this guide, be sure to replace the following variables with your information:
 
   * `DOMAIN_NAME` - Your public domain name to access Jellyfin on (e.g. jellyfin.example.com)
-  * `domain.tld` - The domain name Jellyfin services will run under (e.g. example.com)
+  * `example.com` - The domain name Jellyfin services will run under (e.g. example.com)
   * `SERVER_IP_ADDRESS` - The IP address of your Jellyfin server (if the reverse proxy is on the same server use 127.0.0.1)
 
 In addition, the examples are configured for use with LetsEncrypt certificates.  If you have a certificate from another source, change the ssl configuration from `/etc/letsencrypt/DOMAIN_NAME/` to the location of your certificate and key.
@@ -271,11 +271,11 @@ services:
       traefik.backend: traefik
       traefik.docker.network: traefik
       traefik.port: 8080
-      traefik.frontend.rule: Host:traefik.domain.tld,
+      traefik.frontend.rule: Host:traefik.example.com,
       traefik.frontend.entryPoints: https
       traefik.frontend.passHostHeader: "true"
       traefik.frontend.headers.SSLForceHost: "true"
-      traefik.frontend.headers.SSLHost: traefik.domain.tld
+      traefik.frontend.headers.SSLHost: traefik.example.com
       traefik.frontend.headers.SSLRedirect: "true"
       traefik.frontend.headers.browserXSSFilter: "true"
       traefik.frontend.headers.contentTypeNosniff: "true"
@@ -285,7 +285,7 @@ services:
       traefik.frontend.headers.STSPreload: "true"
       traefik.frontend.headers.customResponseHeaders: X-Robots-Tag:noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex
       traefik.frontend.headers.frameDeny: "true"
-      traefik.frontend.headers.customFrameOptionsValue: 'allow-from https://domain.tld'
+      traefik.frontend.headers.customFrameOptionsValue: 'allow-from https://example.com'
     restart: unless-stopped
 
   jellyfin:
@@ -337,7 +337,7 @@ defaultEntryPoints = ["http", "https"]
 
 [acme]
 acmeLogging = true
-email = "user@domain.tld"
+email = "user@example.com"
 storage = "acme.json"
 entryPoint = "https"
   [acme.dnsChallenge]
@@ -345,10 +345,10 @@ entryPoint = "https"
     delayBeforeCheck = "60"
 
 [[acme.domains]]
-  main = "*.domain.tld"
+  main = "*.example.com"
   
 [docker]
-domain = "domain.tld"
+domain = "example.com"
 network = "traefik"
 exposedbydefault = false
 
@@ -363,10 +363,10 @@ exposedbydefault = false
     passHostHeader = true
     [frontends.jellyfin.routes]
       [frontends.jellyfin.routes.route-jellyfin-ext]
-        rule = "Host:jellyfin.domain.tld"
+        rule = "Host:jellyfin.example.com"
     [frontends.jellyfin.headers]
       SSLRedirect = true
-      SSLHost = "jellyfin.domain.tld"
+      SSLHost = "jellyfin.example.com"
       SSLForceHost = true
       STSSeconds = 315360000
       STSIncludeSubdomains = true
@@ -376,13 +376,13 @@ exposedbydefault = false
       contentTypeNosniff = true
       browserXSSFilter = true
       customResponseHeaders = "X-Robots-Tag:noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex"
-      customFrameOptionsValue = "allow-from https://domain.tld"
+      customFrameOptionsValue = "allow-from https://example.com"
 
 ```
 
 Finally, create an empty acme.json : `touch acme.json` `chmod 600 acme.json` 
 
-IMPORTANT ! Change domain.tld to your domain / subdomain name, and change the mail of the acme (user@example.com in traefik.toml). Let's Encrypt does not require a valid email address however example.com will be flagged as not being a proper email address.
+IMPORTANT ! Change example.com to your domain / subdomain name, and change the mail of the acme (user@example.com in traefik.toml). Let's Encrypt does not require a valid email address however example.com will be flagged as not being a proper email address.
 
 Launch your Traefik/Jellyfin services : `docker-compose up -d`
 
@@ -390,7 +390,7 @@ Congratulations, your stack with Traefik and Jellyfin is UP !
 
 Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in Traefik, you cannot dynamically route to containers when network_mode=host, so we have created a static route to the docker host (172.17.0.1:8096) in `traefik.toml`. Using host networking (or macvlan) is required to use DLNA or an HdHomeRun as it supports multicast networking.
 
-Go to jellyfin.domain.tld (in this case), and your jellyfin is UP with HTTPS (AES 256).
+Go to jellyfin.example.com (in this case), and your jellyfin is UP with HTTPS (AES 256).
 
 ## LetsEncrypt with Certbot
 

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -8,7 +8,7 @@ title: Reverse Proxy
 
 It's possible to run Jellyfin behind another server acting as a reverse proxy.  With a reverse proxy setup, this server handles all network traffic and proxies it back to Jellyfin. This provides the benefits of using DNS names and not having to remember port numbers, as well as easier integration and management of SSL certificates.
 
-Some popular options for reverse proxy systems are [Apache](https://httpd.apache.org/), [Haproxy](https://www.haproxy.com/), [Caddy](https://caddyserver.com/), and [Nginx](https://www.nginx.com/).
+Some popular options for reverse proxy systems are [Apache](https://httpd.apache.org/), [Haproxy](https://www.haproxy.com/), [Nginx](https://www.nginx.com/), [Caddy](https://caddyserver.com/) and [Traefik](https://traefik.io/).
 
 **Important:** In order for a reverse proxy to have the maximum benefit, you should have a publically routable IP address and a domain with DNS set up correctly.  These examples assume you want to run Jellyfin under a sub-domain (ie: jellyfin.example.com), but are easily adapted for the root domain if desired. Running Jellyfin in a subpath (example.com/jellyfin/) is supported by the Android and Web clients.
 

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -15,6 +15,7 @@ Some popular options for reverse proxy systems are [Apache](https://httpd.apache
 When following this guide, be sure to replace the following variables with your information:
 
   * `DOMAIN_NAME` - Your public domain name to access Jellyfin on (e.g. jellyfin.example.com)
+  * `domain.tld` - The domain name Jellyfin services will run under (e.g. example.com)
   * `SERVER_IP_ADDRESS` - The IP address of your Jellyfin server (if the reverse proxy is on the same server use 127.0.0.1)
 
 In addition, the examples are configured for use with LetsEncrypt certificates.  If you have a certificate from another source, change the ssl configuration from `/etc/letsencrypt/DOMAIN_NAME/` to the location of your certificate and key.

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -240,80 +240,6 @@ DOMAIN_NAME {
 }
 ```
 
-## LetsEncrypt with Certbot
-
-LetsEncrypt is a service that provides free SSL/TLS certificates to users.  Certbot is a client that makes this easy to accomplish and automate.  In addition, it has plugins for Apache and Nginx that make automating certificate generation even easier.
-
-Installation instructions for most Linux distributions can be found on the [Certbot website](https://certbot.eff.org/docs/install.html#operating-system-packages).
-
-Once the packages are installed, you're ready to generate a new certificate.
-
-### Apache
-
-After installing certbot and the Apache plugin, certificate generation is accomplished by:
-
-``certbot certonly --apache --noninteractive --agree-tos --email YOUR_EMAIL -d DOMAIN_NAME``
-
-Update the 'SSLCertificateFile' and 'SSLCertificateKeyFile' sections, then restart the service.
-
-Add a job to cron so the certificate will be renwed automatically:
-
-``echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload apache2'" | sudo tee -a /etc/cron.d/renew_certbot``
-
-### HAProxy
-
-HAProxy doesn't currently have a certbot plugin.  To get around this, run certbot in standalone mode and proxy traffic back to it.  
-
-Enable the frontend and backend in the config above, and then run:
-
-``certbot certonly --standalone --preferred-challenges http-01 --http-01-port 8888 --noninteractive --agree-tos --email YOUR_EMAIL -d DOMAIN_NAME``
-
-The port can be changed to anything you like, but be sure that the HAProxy config and your certbot command match.
-
-Haproxy needs to have the certificate and key files concatenated into the same file to read it correctly.  This can be accomplished with the following command.
-
-``cat /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem > /etc/ssl/DOMAIN_NAME.pem``
-
-Uncomment `bind *:443` and the redirect section in the configuration, then reload the service.
-
-#### Automatic Certificate Renewal
-
-Place the following script in `/usr/local/bin/` to automatically update your SSL certificate:
-
-```
-SITE=DOMAIN_NAME
-
-# move to the correct let's encrypt directory
-cd /etc/letsencrypt/live/$SITE
-
-# cat files to make combined .pem for haproxy
-cat fullchain.pem privkey.pem > /etc/ssl/$SITE.pem
-
-# reload haproxy
-service haproxy reload
-```
-
-Make sure the script is executable
-
- ``chmod u+x /usr/local/bin/letsencrypt-renew.sh``
-
-Add a job to cron so the certificate will be renewed automatically:
-
- ``@monthly /usr/bin/certbot renew --renew-hook "/usr/local/bin/letsencrypt-renew.sh" >> /var/log/letsencrypt-renewal.log``
-
-### Nginx
-
-After installing certbot and the Nginx plugin with ``sudo apt install certbot python3-certbot-nginx``, certificate generation is accomplished by:
-
-`sudo certbot --nginx --agree-tos --redirect --hsts --staple-ocsp --email YOUR_EMAIL -d YOUR_DOMAIN`
-(Add the ``--rsa-key-size 4096`` parameter if you want a 4096 bit key instead)
-
-Copy and paste the whole Nginx sample configuration file from above, changing the parameters according to your setup and uncommenting the lines.
-
-Add a job to cron so the certificate will be renewed automatically:
-
-`echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload nginx'" | sudo tee -a /etc/cron.d/renew_certbot`
-
 ## Traefik (with docker-compose)
 
 Traefik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy. Traefik integrates with your existing infrastructure components (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, ...) and configures itself automatically and dynamically. Pointing Traefik at your orchestrator should be the only configuration step you need. (https://traefik.io/). 
@@ -464,7 +390,81 @@ Congratulations, your stack with Traefik and Jellyfin is UP !
 
 Note: Due to a [bug](https://github.com/containous/traefik/issues/5559) in Traefik, you cannot dynamically route to containers when network_mode=host, so we have created a static route to the docker host (172.17.0.1:8096) in `traefik.toml`. Using host networking (or macvlan) is required to use DLNA or an HdHomeRun as it supports multicast networking.
 
-Go to jellyfin.domain.com (in this case), and your jellyfin is UP with HTTPS (AES 256).
+Go to jellyfin.domain.tld (in this case), and your jellyfin is UP with HTTPS (AES 256).
+
+## LetsEncrypt with Certbot
+
+LetsEncrypt is a service that provides free SSL/TLS certificates to users.  Certbot is a client that makes this easy to accomplish and automate.  In addition, it has plugins for Apache and Nginx that make automating certificate generation even easier.
+
+Installation instructions for most Linux distributions can be found on the [Certbot website](https://certbot.eff.org/docs/install.html#operating-system-packages).
+
+Once the packages are installed, you're ready to generate a new certificate.
+
+### Apache
+
+After installing certbot and the Apache plugin, certificate generation is accomplished by:
+
+``certbot certonly --apache --noninteractive --agree-tos --email YOUR_EMAIL -d DOMAIN_NAME``
+
+Update the 'SSLCertificateFile' and 'SSLCertificateKeyFile' sections, then restart the service.
+
+Add a job to cron so the certificate will be renwed automatically:
+
+``echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload apache2'" | sudo tee -a /etc/cron.d/renew_certbot``
+
+### HAProxy
+
+HAProxy doesn't currently have a certbot plugin.  To get around this, run certbot in standalone mode and proxy traffic back to it.  
+
+Enable the frontend and backend in the config above, and then run:
+
+``certbot certonly --standalone --preferred-challenges http-01 --http-01-port 8888 --noninteractive --agree-tos --email YOUR_EMAIL -d DOMAIN_NAME``
+
+The port can be changed to anything you like, but be sure that the HAProxy config and your certbot command match.
+
+Haproxy needs to have the certificate and key files concatenated into the same file to read it correctly.  This can be accomplished with the following command.
+
+``cat /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem > /etc/ssl/DOMAIN_NAME.pem``
+
+Uncomment `bind *:443` and the redirect section in the configuration, then reload the service.
+
+#### Automatic Certificate Renewal
+
+Place the following script in `/usr/local/bin/` to automatically update your SSL certificate:
+
+```
+SITE=DOMAIN_NAME
+
+# move to the correct let's encrypt directory
+cd /etc/letsencrypt/live/$SITE
+
+# cat files to make combined .pem for haproxy
+cat fullchain.pem privkey.pem > /etc/ssl/$SITE.pem
+
+# reload haproxy
+service haproxy reload
+```
+
+Make sure the script is executable
+
+ ``chmod u+x /usr/local/bin/letsencrypt-renew.sh``
+
+Add a job to cron so the certificate will be renewed automatically:
+
+ ``@monthly /usr/bin/certbot renew --renew-hook "/usr/local/bin/letsencrypt-renew.sh" >> /var/log/letsencrypt-renewal.log``
+
+### Nginx
+
+After installing certbot and the Nginx plugin with ``sudo apt install certbot python3-certbot-nginx``, certificate generation is accomplished by:
+
+`sudo certbot --nginx --agree-tos --redirect --hsts --staple-ocsp --email YOUR_EMAIL -d YOUR_DOMAIN`
+(Add the ``--rsa-key-size 4096`` parameter if you want a 4096 bit key instead)
+
+Copy and paste the whole Nginx sample configuration file from above, changing the parameters according to your setup and uncommenting the lines.
+
+Add a job to cron so the certificate will be renewed automatically:
+
+`echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload nginx'" | sudo tee -a /etc/cron.d/renew_certbot`
 
 # Final steps
 


### PR DESCRIPTION
Based on the changes proposed by @Artiume 

- Moved Traefik and Jellyfin to a single docker-compose.yml
- Removed some config items
- Added functional host networking so DLNA and LiveTV work
- Used static rules to point to docker host from Traefik network
- Changed docker-compose version to 3.5 (to support network name) - there are other workarounds but this is more copy/paste friendly