### PR TITLE
Update to HW Accel to show how to pass devices and update Rpi4 Information

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -139,7 +139,9 @@ Useful resources:
 3. Change the amount of memory allocated to the GPU, as the Pi's GPU can't handle accelerated decoding and encoding simultaneously:
     `sudo nano /boot/config.txt`
     
-    Add the line `gpu_mem=320` [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
+    For Rpi4, add the line `gpu_mem=320` [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
+    
+    For Rpi3, add the line `gpu_mem=256`
     
     You can set any value, but 320 is recommended amount for [4K HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt). 
     

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -137,4 +137,4 @@ Useful resources:
     
     You can set any value, but 256 was thoroughly tested to be the minimum recommended for the best results.
 
-Note: In testing transcoding was not working fast enough on Rpi3 to run in real time because the video was being resized. Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264
+Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. Active cooling (fan) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -139,6 +139,6 @@ Useful resources:
     
     Add the line `gpu_mem=320`. [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
     
-    You can set any value, but 256 was thoroughly tested to be the minimum recommended for the best results.
+    You can set any value, but 320 is recommended amount for [HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt)
 
 Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. Active cooling (fan) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -77,8 +77,9 @@ services:
       - /path/to/cache:/cache  
       - /path/to/media:/media  
     devices: 
-      - /dev/dri/renderD128:/dev/dri/renderD128
+      - /dev/dri/renderD128:/dev/dri/renderD128 # VAAPI devices, may be D128, D129, etc.
       - /dev/dri/card0:/dev/dri/card0
+      - /dev/vchiq:/dev/qchiq  # Rpi4
       
 ```
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -165,4 +165,4 @@ Stream #0:1 -> #0:1 (aac (native) -> mp3 (libmp3lame))
 
 stream #0:0 used software to decode hevc and used HWA to encode.
 
-stream #0:1 used software to transcode completely. That's fine, it doesn't consume as much processing power. 
+stream #0:1 had the same results. Decoding is easier than encoding so these are overall good results.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -8,7 +8,7 @@ title: Hardware Acceleration
 
 Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through the Video Acceleration API (VAAPI).
 
-[VAAPI](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a VA-API (video accelerated API) that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VAAPI and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md), their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
+[VAAPI](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a Video Acceleration API that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VAAPI and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md) and their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
 
 OS | Recommended HW Acceleration
 ------------ | -------------

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -32,6 +32,8 @@ Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-co
 
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 
 
+CentOS may require [additional drivers](https://www.getpagespeed.com/server-setup/how-to-enable-intel-hardware-acceleration-for-video-playback-in-rhel-centos-8) for QSV
+
 Here's [additional information](https://github.com/Artiume/jellyfin-docs/blob/master/general/wiki/main.md) to learn more. 
 
 ## Enabling Hardware Acceleration

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -6,7 +6,7 @@ title: Hardware Acceleration
 
 # Hardware Acceleration
 
-Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through the Video Acceleration API (VAAPI).
+Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through Video Acceleration API's.
 
 [VAAPI](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a Video Acceleration API that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VAAPI and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md) and their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -149,4 +149,4 @@ Useful resources:
     
     Use `vcgencmd get_mem arm && vcgencmd get_mem gpu` to verify the split between CPU and GPU memory.
 
-Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.
+Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for transcoding. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -150,3 +150,19 @@ Useful resources:
     Use `vcgencmd get_mem arm && vcgencmd get_mem gpu` to verify the split between CPU and GPU memory.
 
 Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for transcoding. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.
+
+### Verifying Transcodes
+
+To verify that you are using the proper libraries, run this command against your transcoding log. This can be found at Admin Dashboard > Logs, and /var/log/jellyfin if instead via the repository.
+
+grep -A2 'Stream mapping:' /var/log/jellyfin/ffmpeg-transcode-85a68972-7129-474c-9c5d-2d9949021b44.txt
+
+This returned the result:
+
+Stream mapping:    
+Stream #0:0 -> #0:0 (hevc (native) -> h264 (h264_omx))    
+Stream #0:1 -> #0:1 (aac (native) -> mp3 (libmp3lame)) 
+
+stream #0:0 used software to decode hevc and used HWA to encode.
+
+stream #0:1 used software to transcode completely. That's fine, it doesn't consume as much processing power. 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -6,7 +6,7 @@ title: Hardware Acceleration
 
 # Hardware Acceleration
 
-Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX, and MediaCodec through the Video Acceleration API (VAAPI).
+Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through the Video Acceleration API (VAAPI).
 
 [VAAPI](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a VA-API (video accelerated API) that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VAAPI and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md), their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -149,4 +149,4 @@ Useful resources:
     
     Use `vcgencmd get_mem arm && vcgencmd get_mem gpu` to verify the split between CPU and GPU memory.
 
-Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. Active cooling (fan) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.
+Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -12,7 +12,7 @@ Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIn
 
 OS | Recommended HW Acceleration
 ------------ | -------------
-Linux/GNU | QSV, NVENC, VAAPI 
+Linux/GNU | QSV, NVENC, VAAPI
 Windows | QSV, NVENC, AMF, VAAPI
 MacOS | None (videotoolbox support coming)
 Android | MediaCodec, OMX

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -18,19 +18,17 @@ MacOS | None (videotoolbox support coming)
 Android | MediaCodec, OMX
 RPi | OMX
 
-[NVIDIA using ffmpeg official list](https://developer.nvidia.com/ffmpeg). Not every card has been tested. These [drivers](https://github.com/keylase/nvidia-patch) are recommended for Linux/GNU and Windows. Here is the official list of [NVIDIA Graphics Cards](https://developer.nvidia.com/video-encode-decode-gpu-support-matrix) for supported codecs. 
+[Graphics Cards comparison using HWA](https://www.elpamsoft.com/?p=Plex-Hardware-Transcoding)
+
+[NVIDIA using ffmpeg official list](https://developer.nvidia.com/ffmpeg). Not every card has been tested. These [drivers](https://github.com/keylase/nvidia-patch) are recommended for Linux/GNU and Windows. Here is the official list of [NVIDIA Graphics Cards](https://developer.nvidia.com/video-encode-decode-gpu-support-matrix) for supported codecs. Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comments/amuyba/nvenc_nvdec_working_in_jellyfin_on_ubuntu_server/).
 
 List of supported codecs for [VAAPI](https://wiki.archlinux.org/index.php/Hardware_video_acceleration#Comparison_tables).
 
-Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comments/amuyba/nvenc_nvdec_working_in_jellyfin_on_ubuntu_server/).
-
 AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4) and AMD GFX Cards are required to use VAAPI on linux.
 
-Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
-
-[Graphics Cards comparison using HWA](https://www.elpamsoft.com/?p=Plex-Hardware-Transcoding)
-
 Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need APU or dGPU. It will be a while before AV1 hardware acceleration shows up though (realistically 2020+).
+
+Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
 
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 
 
@@ -165,4 +163,4 @@ Stream #0:1 -> #0:1 (aac (native) -> mp3 (libmp3lame))
 
 stream #0:0 used software to decode hevc and used HWA to encode.
 
-stream #0:1 had the same results. Decoding is easier than encoding so these are overall good results.
+stream #0:1 had the same results. Decoding is easier than encoding so these are overall good results. HWA decoding is a work in progress.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -66,7 +66,7 @@ Note: [NVIDIA GPU's](https://github.com/docker/compose/issues/6691) currently ar
   
 Alternatively, using docker-compose:  
 
-```
+```yaml
 version: "3"  
 services:  
   jellyfin:  

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -26,6 +26,8 @@ Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comment
 
 AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4) and AMD GFX Cards are required to use VAAPI on linux.
 
+Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
+
 Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need APU or dGPU. It will be a while before AV1 hardware acceleration shows up though (realistically 2020+).
 
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -139,6 +139,6 @@ Useful resources:
     
     Add the line `gpu_mem=320`. [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
     
-    You can set any value, but 320 is recommended amount for [HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt)
+    You can set any value, but 320 is recommended amount for [4K HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt)
 
 Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. Active cooling (fan) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -30,7 +30,7 @@ Zen is CPU only. No hardware acceleration for any form of video decoding/encodin
 
 Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
 
-On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 
+On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not supported by of Jellyfin. 
 
 CentOS may require [additional drivers](https://www.getpagespeed.com/server-setup/how-to-enable-intel-hardware-acceleration-for-video-playback-in-rhel-centos-8) for QSV
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -43,6 +43,40 @@ The hardware acceleration is available immediately for media playback. No server
 
 Each hardware acceleration type, as well as each Jellyfin installation type, requires different setup options before it can be used. It is always best to consult the FFMpeg documentation on the acceleration type you choose for the latest information.
 
+### Acceleration on Docker
+
+In order to use Hardware acceleration in Docker, the devices must be passed to the container. To see what video devices are available, you can run `sudo lshw -c video` or `vainfo`
+
+ Docker run configuration example:
+ 
+   `docker run -d \`  
+    `--volume /path/to/config:/config \`  
+    `--volume /path/to/cache:/cache \`  
+    `--volume /path/to/media:/media \`  
+    `--net=host \`  
+    `--restart=unless-stopped \`  
+    `--device /dev/dri/renderD128:/dev/dri/renderD128 \`  
+    `--device /dev/dri/card0:/dev/dri/card0 \`  
+    `jellyfin/jellyfin`
+  
+Alternatively, using docker-compose:  
+
+```
+version: "3"  
+services:  
+  jellyfin:  
+    image: jellyfin/jellyfin
+    network_mode: "host"  
+    volumes:  
+      - /path/to/config:/config  
+      - /path/to/cache:/cache  
+      - /path/to/media:/media  
+    devices: 
+      - /dev/dri/renderD128:/dev/dri/renderD128
+      - /dev/dri/card0:/dev/dri/card0
+      
+```
+
 ### Configuring VAAPI acceleration on Debian/Ubuntu from `.deb` packages
 
 Configuring VAAPI on Debian/Ubuntu requires some additional configuration to ensure permissions are correct.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -28,6 +28,8 @@ AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSD
 
 Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
 
+[Graphics Cards comparison using HWA](https://www.elpamsoft.com/?p=Plex-Hardware-Transcoding)
+
 Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need APU or dGPU. It will be a while before AV1 hardware acceleration shows up though (realistically 2020+).
 
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -26,7 +26,7 @@ List of supported codecs for [VAAPI](https://wiki.archlinux.org/index.php/Hardwa
 
 AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4) and AMD GFX Cards are required to use VAAPI on linux.
 
-Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need APU or dGPU. It will be a while before AV1 hardware acceleration shows up though (realistically 2020+).
+Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need an APU or dGPU for hardware acceleration.
 
 Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/cloud-computing/cloud-computing-quicksync-video-ffmpeg-white-paper.html)
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -137,8 +137,10 @@ Useful resources:
 3. Change the amount of memory allocated to the GPU, as the Pi's GPU can't handle accelerated decoding and encoding simultaneously:
     `sudo nano /boot/config.txt`
     
-    Add the line `gpu_mem=320`. [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
+    Add the line `gpu_mem=320` [See more Here](https://www.raspberrypi.org/documentation/configuration/config-txt/)
     
-    You can set any value, but 320 is recommended amount for [4K HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt)
+    You can set any value, but 320 is recommended amount for [4K HEVC](https://github.com/CoreELEC/CoreELEC/blob/coreelec-9.2/projects/RPi/devices/RPi4/config/config.txt). 
+    
+    Use `vcgencmd get_mem arm && vcgencmd get_mem gpu` to verify the split between CPU and GPU memory.
 
 Note:  Rpi4 currently doesn't support HWA decoding, only HWA encoding of H.264. Active cooling (fan) is required, passive cooling is insufficient for HWA. For Rpi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -26,6 +26,8 @@ Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comment
 
 AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4) and AMD GFX Cards are required to use VAAPI on linux.
 
+Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You need APU or dGPU. It will be a while before AV1 hardware acceleration shows up though (realistically 2020+).
+
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 
 
 Here's [additional information](https://github.com/Artiume/jellyfin-docs/blob/master/general/wiki/main.md) to learn more. 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -47,6 +47,8 @@ Each hardware acceleration type, as well as each Jellyfin installation type, req
 
 In order to use Hardware acceleration in Docker, the devices must be passed to the container. To see what video devices are available, you can run `sudo lshw -c video` or `vainfo`
 
+Note: [NVIDIA GPU's](https://github.com/docker/compose/issues/6691) currently aren't supported in Docker-compose. 
+
  Docker run configuration example:
  
    `docker run -d \`  

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -6,7 +6,7 @@ title: Hardware Acceleration
 
 # Hardware Acceleration
 
-Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX, and MediaCodec through the Video Acceleration API (VAAPI), and others.
+Jellyfin supports [hardware acceleration](https://trac.ffmpeg.org/wiki/HWAccelIntro) (HWA) of video encoding/decoding using FFMpeg. FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX, and MediaCodec through the Video Acceleration API (VAAPI).
 
 [VAAPI](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a VA-API (video accelerated API) that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VAAPI and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md), their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -24,6 +24,8 @@ List of supported codecs for [VAAPI](https://wiki.archlinux.org/index.php/Hardwa
 
 Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comments/amuyba/nvenc_nvdec_working_in_jellyfin_on_ubuntu_server/).
 
+AMF Linux Support still [not official](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/4) and AMD GFX Cards are required to use VAAPI on linux.
+
 On Windows you can use DXVA2/D3D11VA libraries for decoding instead of libmfx, and HWA encoding on Windows requires libmfx. The DXVA2/D3D11VA libraries are currently not part of Jellyfin. 
 
 Here's [additional information](https://github.com/Artiume/jellyfin-docs/blob/master/general/wiki/main.md) to learn more. 


### PR DESCRIPTION
Provide additional documentation to show how to properly access hardware for docker. 

I want to raise the question of the purpose of the installing page, I was blocked from adding reverse proxy information on that page for docker so I am forced to add the hardware acceleration context here. I don't like how several pages must be referenced in order to get a fully working docker compose. Any suggestions?