### PR TITLE
Skeleton Codec Support Page

### DIFF
--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -80,7 +80,7 @@ If the container is unsupported, this will result in remuxing. The video and aud
 |[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
 |[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
-|[webM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|||||
+|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|||||
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -86,4 +86,4 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 <sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in Firefox and will remux.
 
-<sup>3</sup>MKV containers are improperly labeled as webM in Firefox during playback.
+<sup>3</sup>MKV containers are improperly labeled as WebM in Firefox during playback.

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -55,7 +55,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |VobSub|Picture|❌|✅|✅|🔶|
 |DVB-SUB|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
-|PGSSUB|Picture|❌||❌|❌|
+|PGSSUB|Picture|❌|❌|❌|❌|
 
 
 Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -9,34 +9,43 @@ title: Codec Compatibility
  
 ## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 
-||Browser|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-|[MPEG4 ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2)<sup>4</sup>|❌|❌|❌|✅|✅|
-|[H.262/DivX](https://en.wikipedia.org/wiki/DivX)|✅|✅|✅|✅|✅|
-|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|🔶<sup>3</sup>|✅|✅|✅|✅|
-|[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
+||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌|❌|✅|✅|
+|[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌|❌|✅|✅|
+|[H.264 8Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅|✅|✅|
+|[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅|✅|✅|✅|
+|[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
 
 <sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
 
-<sup>3</sup>H.264 10Bit is unsupported.
+[Format Cheetsheet:](https://en.wikipedia.org/wiki/MPEG-4#MPEG-4_Parts)
 
-<sup>4</sup>This is the codec format for Xvid encodes.
+|[MPEG-2](https://en.wikipedia.org/wiki/MPEG-2)|[MPEG-2<br>Part 2](https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2)|[MPEG-4<br>Part-2](https://en.wikipedia.org/wiki/MPEG-4_Part_2)<sup>1</sup>|[MPEG-4<br>Part-10](https://en.wikipedia.org/wiki/Advanced_Video_Coding)|[MPEG-4<br>Part-14](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|[MPEG-H<br>Part 2](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding)|
+|:---:|:---:|:---:|:---:|:---:|:---:|
+|H.262|MPEG-2 Video|MPEG4 SP/ASP|H.264|MP4 Container<sup>2</sup>|H.265|
+|DVD-Video||DivX|MPEG-4 AVC||HEVC|
+|||DX50||||
+
+<sup>1</sup>[MPEG-4 Part-2 vs Part-10](https://www.afterdawn.com/glossary/term.cfm/mpeg_4_part_10)
+
+<sup>2</sup>[MPEG-4 Part 17: MP4TT Subtitles](https://en.wikipedia.org/wiki/MPEG-4_Part_17)
 
 ## [Audio Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Audio_coding_formats_support "Wikipedia's audio codec tables")
 
 If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video coding.
 
-||Browser|Android|AndroidTV|Kodi|Roku|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-FLAC|✅|✅|✅|✅|✅|
-|MP3|🔶<sup>1</sup>|✅|✅|✅|✅|
-|AAC|🔶<sup>2</sup>|✅|✅|✅|✅|
-|AC3|✅|❌|✅|✅|✅|
-|EAC3<sup>3/sup>|✅|✅|✅|✅|✅|
-|VORBIS|❌|✅|✅|✅|✅|
-|DTS<sup>4</sup>|❌|❌|❌|✅|✅|
+||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|Roku|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+FLAC|✅|❌|✅|✅|✅|✅|✅|
+|MP3|🔶<sup>1</sup>|✅|✅|✅|✅|✅|✅|
+|AAC|🔶<sup>2</sup>|✅|✅|✅|✅|✅|✅|
+|AC3|✅|❌|✅|✅|✅|✅|✅|
+|EAC3<sup>3/sup>|✅|✅|✅|✅|✅|✅|✅|
+|VORBIS|❌|✅|✅|✅|✅|✅|✅|
+|DTS<sup>4</sup>|❌|❌|❌|✅|✅|✅|✅|
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
@@ -52,10 +61,10 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
-|SubRip Text (SRT)|Formatted Text|❌|🔶|✅|🔶|
+|SubRip Text (.srt)|Formatted Text|❌|🔶|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
-|DVB-SUB|Picture|✅|❌|✅|❌|
+|DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
 |PGSSUB|Picture|❌|❌|✅|❌|
 
@@ -75,6 +84,6 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 
-<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
+<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in Firefox and will remux.
 
-<sup>3</sup>MKV containers are improperly labeled as webM during playback. 
+<sup>3</sup>MKV containers are improperly labeled as webM in Firefox during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -4,20 +4,23 @@ title: Codec Compatibility
 ---
 
  # [Codec Tables](https://en.wikipedia.org/wiki/List_of_codecs "Wikipedia's list of all codecs")
+ 
+ The goal is to DirectPlay all media. This means the container, video, audio and subtitles are all compatible with the client. DirectStream will occur if the audio, container or subtitles happen to not be supported. Subtitles can be tricky because they can cause DirectStreaming (subtitles are remuxed) or video transcoding (burning in subtitles) to occur. If the video codec is unsupported, this will result in video transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
+ 
 ## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 
-If the video codec is unsupported, this will result in transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
-
-||WebOS|Android|AndroidTV|Kodi|Roku|
+||WebOS|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |[H.262/Xvid](https://en.wikipedia.org/wiki/MPEG-4_Part_2)|✅|✅|✅|✅|✅|
 |[H.262/DivX](https://en.wikipedia.org/wiki/DivX)|✅|✅|✅|✅|✅|
-|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅|
+|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅<sup>3</sup>|✅|✅|✅|✅|
 |[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
 
 <sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
+
+<sup>3</sup>H.264 10Bit is unsupported.
 
 ## [Audio Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Audio_coding_formats_support "Wikipedia's audio codec tables")
 
@@ -28,22 +31,29 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 |MP3|🔶<sup>1</sup>|✅|✅|✅|✅
 |AAC|✅|✅|✅|✅|✅
 |AC3|✅|✅|✅|✅|✅
+|EAC3<sup>2</sup>|✅|✅|✅|✅|✅
+|VORBIS|❌|✅|✅|✅|✅
+
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported.
+
+<sup>2</sup>Only EAC3 2.0 has been tested.
 
 ## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
 
 Subtiles can be a subtle issue for transcoding. Containers have a limited number of subtitles that are supported. If subtitles need to be transcoded, it will happen one of two ways. They can be converted into another supported format (text-based subtitles) or burned into the video (image/lossless based and ASS based) due to the subtitles transcoding not being supported. This is the most intenstive method of transcoding due to two transcodings happening at once; applying the subtitle layer on top of the video layer. 
 
+Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
+
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
-If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process, remuxing speed can be up to 10000x real time, remuxing + audio (ac3 2ch to aac 2ch) happened at 100x real time on the same sample.
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a Rpi3.
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
 |[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|✅|✅|✅|✅|✅
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>1, 2</sup>|❌|🔶|🔶|🔶|🔶
-|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|❌|✅|✅|✅|✅
+|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
 
 
 <sup>1</sup>MKV containers can hold nearly any codec. *support not verified, initial testing is showing that all containers convert to ts using hls streaming protocol* Mp4 successfully streamed using http protocol instead of hls protocol and did not remux.

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -18,7 +18,7 @@ title: Codec Compatibility
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
 
-<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Direct Stream.
+<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
 
 <sup>3</sup>H.264 10Bit is unsupported.
 
@@ -53,28 +53,28 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |SubRip Text (SRT)|Formatted Text|❌|🔶|✅|🔶|
-|ASS/SSA|Formatted Text|❌|❌|✅|🔶|
+|ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
 |DVB-SUB|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
-|PGSSUB|Picture|❌|❌|❌|❌|
+|PGSSUB|Picture|❌|❌|✅|❌|
 
 
-Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
+<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
 If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a Rpi3.
 
-||WebOS|Android|AndroidTV|Kodi|Roku
+||Browser|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
-|[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
+|[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
-|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
-|[webM](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|||||
+|[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
+|[webM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|||||
 
-<sup>1</sup>mp4 containers are one of the few containers that will not remux.
+<sup>1</sup>MP4 containers are one of the few containers that will not remux.
 
-<sup>2</sup>mkv containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
+<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
 
-<sup>3</sup>mkv containers are improperly labeled as webm during playback. 
+<sup>3</sup>MKV containers are improperly labeled as webM during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -5,17 +5,19 @@ title: Codec Compatibility
 
  # [Codec Tables](https://en.wikipedia.org/wiki/List_of_codecs "Wikipedia's list of all codecs")
  
- The goal is to Direct Play all media. This means the container, video, audio and subtitles are all compatible with the client. Direct Stream will occur if the audio, container or subtitles happen to not be supported. Subtitles can be tricky because they can cause Direct Stream (subtitles are remuxed) or video transcoding (burning in subtitles) to occur. If the video codec is unsupported, this will result in video transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
- 
+The goal is to Direct Play all media. This means the container, video, audio and subtitles are all compatible with the client. Direct Stream will occur if the audio, container or subtitles happen to not be supported. Subtitles can be tricky because they can cause Direct Stream (subtitles are remuxed) or video transcoding (burning in subtitles) to occur. If the video codec is unsupported, this will result in video transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
+
 ## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 
-||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌|❌|✅|✅|
-|[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌|❌|✅|✅|
-|[H.264 8Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅|✅|✅|
-|[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅|✅|✅|✅|
-|[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
+[Breakdown of video codecs.](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)
+
+||Chrome|Firefox|Safari|Android|iOS|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌||❌|✅||
+|[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌||❌|✅||
+|[H.264 8Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅||✅|✅||
+|[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅||✅|✅||
+|[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>||❌|✅||
 
 <sup>1</sup>HEVC support is potentially available by offloading to the operating system, but this has not been tested.
 
@@ -37,15 +39,15 @@ title: Codec Compatibility
 
 If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video coding.
 
-||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|Roku|
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-FLAC|✅|❌|✅|✅|✅|✅|✅|
-|MP3|🔶<sup>1</sup>|🔶|✅|✅|✅|✅|✅|
-|AAC|🔶<sup>2</sup>|🔶|✅|✅|✅|✅|✅|
-|AC3|✅|❌|✅|✅|✅|✅|✅|
-|EAC3<sup>3</sup>|✅|✅|✅|✅|✅|✅|✅|
-|VORBIS|❌|✅|✅|✅|✅|✅|✅|
-|DTS<sup>4</sup>|❌|❌|❌|✅|✅|✅|✅|
+||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Kodi|Roku|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+FLAC|✅|❌|✅|✅||✅|✅||
+|MP3|🔶<sup>1</sup>|🔶|✅|✅||✅|✅||
+|AAC|🔶<sup>2</sup>|🔶|✅|✅||✅|✅||
+|AC3|✅|❌|✅|✅||✅|✅||
+|EAC3<sup>3</sup>|✅|✅|✅|✅||✅|✅||
+|VORBIS|❌|✅|✅|✅||✅|✅||
+|DTS<sup>4</sup>|❌|❌|❌|✅||✅|✅||
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
@@ -79,11 +81,13 @@ If the container is unsupported, this will result in remuxing. The video and aud
 |:---:|:---:|:---:|:---:|:---:|:---:
 |[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
-|[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
-|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|||||
+|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|✅||||
+|[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>4</sup>|✅|✅|✅|✅|✅
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 
 <sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in Firefox and will remux.
 
 <sup>3</sup>MKV containers are improperly labeled as WebM in Firefox during playback.
+
+<sup>4</sup>TS is one of the primary containers for streaming using Jellyfin. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -26,11 +26,11 @@ The goal is to Direct Play all media. This means the container, video, audio and
 
 [Format Cheetsheet:](https://en.wikipedia.org/wiki/MPEG-4#MPEG-4_Parts)
 
-|[MPEG-2](https://en.wikipedia.org/wiki/MPEG-2)|[MPEG-2<br>Part 2](https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2)|[MPEG-4<br>Part-2](https://en.wikipedia.org/wiki/MPEG-4_Part_2)<sup>1</sup>|[MPEG-4<br>Part-10](https://en.wikipedia.org/wiki/Advanced_Video_Coding)|[MPEG-4<br>Part-14](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|[MPEG-H<br>Part 2](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding)|
-|:---:|:---:|:---:|:---:|:---:|:---:|
-|H.262|MPEG-2 Video|MPEG4 SP/ASP|H.264|MP4 Container<sup>2</sup>|H.265|
-|DVD-Video||DivX|MPEG-4 AVC||HEVC|
-|||DX50||||
+|[MPEG-2<br>Part 2](https://en.wikipedia.org/wiki/H.262/MPEG-2_Part_2)|[MPEG-4<br>Part-2](https://en.wikipedia.org/wiki/MPEG-4_Part_2)<sup>1</sup>|[MPEG-4<br>Part-10](https://en.wikipedia.org/wiki/Advanced_Video_Coding)|[MPEG-4<br>Part-14](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|[MPEG-H<br>Part 2](https://en.wikipedia.org/wiki/High_Efficiency_Video_Coding)|
+|:---:|:---:|:---:|:---:|:---:|
+|H.262|MPEG4 SP/ASP|H.264|MP4 Container<sup>2</sup>|H.265|
+|MPEG-2 Video|DivX|MPEG-4 AVC||HEVC|
+|DVD-Video|DX50||||
 
 <sup>1</sup>[MPEG-4 Part-2 vs Part-10](https://www.afterdawn.com/glossary/term.cfm/mpeg_4_part_10)
 
@@ -50,6 +50,13 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 |VORBIS<sup>3</sup>|✅|✅|✅|✅||||✅|✅|
 |DTS<sup>4</sup>|❌|❌|❌|✅||||✅|✅|
 
+[Format Cheetsheet:](https://en.wikipedia.org/wiki/Moving_Picture_Experts_Group#External_links)
+
+|[MPEG-1](https://en.wikipedia.org/wiki/MPEG-1)|[MPEG-2](https://en.wikipedia.org/wiki/MPEG-2)|
+|:---:|:---:|
+|[MP2 (layer 2)](https://en.wikipedia.org/wiki/MPEG-1_Audio_Layer_II)|[AAC (Part 7)](https://en.wikipedia.org/wiki/Advanced_Audio_Coding)|
+|[MP3 (layer 3)](https://en.wikipedia.org/wiki/MP3)||
+
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
 <sup>2</sup>Only EAC3 2.0 has been tested.
@@ -68,7 +75,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |[WebVTT (VTT)](https://en.wikipedia.org/wiki/WebVTT)|Text|❌<sup>1</sup>|❌<sup>1</sup>|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
-|DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
+|DVB-SUB [(SUB + IDX](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
 |PGSSUB|Picture|❌|❌|✅|❌|
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -13,7 +13,7 @@ title: Codec Compatibility
 |:---:|:---:|:---:|:---:|:---:|:---:|
 |[H.262/Xvid](https://en.wikipedia.org/wiki/MPEG-4_Part_2)|✅|✅|✅|✅|✅|
 |[H.262/DivX](https://en.wikipedia.org/wiki/DivX)|✅|✅|✅|✅|✅|
-|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅<sup>3</sup>|✅|✅|✅|✅|
+|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|🔶<sup>3</sup>|✅|✅|✅|✅|
 |[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
@@ -43,6 +43,14 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 
 Subtiles can be a subtle issue for transcoding. Containers have a limited number of subtitles that are supported. If subtitles need to be transcoded, it will happen one of two ways. They can be converted into another supported format (text-based subtitles) or burned into the video (image/lossless based and ASS based) due to the subtitles transcoding not being supported. This is the most intenstive method of transcoding due to two transcodings happening at once; applying the subtitle layer on top of the video layer. 
 
+||Format|TS|MP4|MKV|AVI|
+|:---:|:---:|:---:|:---:|:---:|:---:|
+|SubRip Text (SRT)|Formatted Text|❌|🔶|✅|🔶|
+|ASS/SSA|Formatted Text|❌|❌|✅|🔶|
+|VobSub|Picture|❌|✅|✅|🔶|
+|DVB-SUB|Picture|✅|❌|✅|❌|
+|MP4TT/TXTT|XML|❌|✅|❌|❌|
+
 Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
@@ -51,11 +59,12 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
-|[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|✅|✅|✅|✅|✅
-|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>1, 2</sup>|❌|🔶|🔶|🔶|🔶
+|[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
+|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
 |[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
 
+<sup>1</sup>mp4 containers are one of the few containers that will not remux.
 
-<sup>1</sup>MKV containers can hold nearly any codec. *support not verified, initial testing is showing that all containers convert to ts using hls streaming protocol* Mp4 successfully streamed using http protocol instead of hls protocol and did not remux.
+<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
 
-<sup>2</sup>webm containers that have file extension mkv are marked as mkv on the media info page, and properly labeled as webm during playback. 
+<sup>3</sup>webm containers that have file extension mkv are marked as mkv on the media info page, and properly labeled as webm during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -9,9 +9,9 @@ title: Codec Compatibility
  
 ## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 
-||WebOS|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
+||Browser|Android|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
 |:---:|:---:|:---:|:---:|:---:|:---:|
-|[H.262/Xvid](https://en.wikipedia.org/wiki/MPEG-4_Part_2)|✅|✅|✅|✅|✅|
+|[MPEG4 ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2)<sup>4</sup>|❌|❌|❌|✅|✅|
 |[H.262/DivX](https://en.wikipedia.org/wiki/DivX)|✅|✅|✅|✅|✅|
 |[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|🔶<sup>3</sup>|✅|✅|✅|✅|
 |[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
@@ -22,22 +22,27 @@ title: Codec Compatibility
 
 <sup>3</sup>H.264 10Bit is unsupported.
 
+<sup>4</sup>This is the codec format for Xvid encodes.
+
 ## [Audio Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Audio_coding_formats_support "Wikipedia's audio codec tables")
 
 If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video coding.
 
-||WebOS|Android|AndroidTV|Kodi|Roku
-|:---:|:---:|:---:|:---:|:---:|:---:
-|MP3|🔶<sup>1</sup>|✅|✅|✅|✅
-|AAC|✅|✅|✅|✅|✅
-|AC3|✅|✅|✅|✅|✅
-|EAC3<sup>2</sup>|✅|✅|✅|✅|✅
-|VORBIS|❌|✅|✅|✅|✅
+||Browser|Android|AndroidTV|Kodi|Roku|
+|:---:|:---:|:---:|:---:|:---:|:---:|
+FLAC|✅|✅|✅|✅|✅|
+|MP3|🔶<sup>1</sup>|✅|✅|✅|✅|
+|AAC|🔶<sup>2</sup>|✅|✅|✅|✅|
+|AC3|✅|❌|✅|✅|✅|
+|EAC3<sup>3/sup>|✅|✅|✅|✅|✅|
+|VORBIS|❌|✅|✅|✅|✅|
 
 
-<sup>1</sup>MP3 Mono is incorrectly reported as unsupported.
+<sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
-<sup>2</sup>Only EAC3 2.0 has been tested.
+<sup>2</sup> AAC is incorrectly reported as unsupported and will transcode to MP3.
+
+<sup>3</sup>Only EAC3 2.0 has been tested.
 
 ## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
 
@@ -50,21 +55,24 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |VobSub|Picture|❌|✅|✅|🔶|
 |DVB-SUB|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
+|PGSSUB|Picture|❌||❌|❌|
+
 
 Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
-If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a RPi3.
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a Rpi3.
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
 |[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
 |[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
+|[webM](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|||||
 
 <sup>1</sup>mp4 containers are one of the few containers that will not remux.
 
-<sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
+<sup>2</sup>mkv containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
 
 <sup>3</sup>mkv containers are improperly labeled as webm during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -18,7 +18,7 @@ title: Codec Compatibility
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
 
-<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
+<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Direct Stream.
 
 <sup>3</sup>H.264 10Bit is unsupported.
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -69,7 +69,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |PGSSUB|Picture|❌|❌|✅|❌|
 
 
-<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of JF. 
+<sup>1</sup>ASS Subtitles are only supported by mkv files. MKV files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of Jellyfin.
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -60,7 +60,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |PGSSUB|Picture|❌|❌|✅|❌|
 
 
-<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files can't natively be streamed therefore ASS subtitles will always inherently be burned into the video. This is not a limitation of JF. 
+<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files aren't supported by browsers.They will always inherently be burned into the video. This is not a limitation of JF. 
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -36,13 +36,15 @@ FLAC|✅|✅|✅|✅|✅|
 |AC3|✅|❌|✅|✅|✅|
 |EAC3<sup>3/sup>|✅|✅|✅|✅|✅|
 |VORBIS|❌|✅|✅|✅|✅|
-
+|DTS<sup>4</sup>|❌|❌|❌|✅|✅|
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
 <sup>2</sup> AAC is incorrectly reported as unsupported and will transcode to MP3.
 
 <sup>3</sup>Only EAC3 2.0 has been tested.
+
+<sup>4</sup> Only DTS Mono has been tested.
 
 ## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -61,7 +61,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
-|SubRip Text (.srt)|Formatted Text|❌|🔶|✅|🔶|
+|SubRip Text (.srt)|Text|❌|🔶|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
 |DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
@@ -69,7 +69,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |PGSSUB|Picture|❌|❌|✅|❌|
 
 
-<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files aren't supported by browsers.They will always inherently be burned into the video. This is not a limitation of JF. 
+<sup>1</sup>ASS Subtitles are only supported by mkv files. Mkv files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of JF. 
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -17,7 +17,7 @@ title: Codec Compatibility
 |[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅|✅|✅|✅|
 |[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
 
-<sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
+<sup>1</sup>HEVC support is potentially available by offloading to the operating system, but this has not been tested.
 
 <sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Direct Stream.
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -40,10 +40,10 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 ||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|Roku|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 FLAC|✅|❌|✅|✅|✅|✅|✅|
-|MP3|🔶<sup>1</sup>|✅|✅|✅|✅|✅|✅|
-|AAC|🔶<sup>2</sup>|✅|✅|✅|✅|✅|✅|
+|MP3|🔶<sup>1</sup>|🔶|✅|✅|✅|✅|✅|
+|AAC|🔶<sup>2</sup>|🔶|✅|✅|✅|✅|✅|
 |AC3|✅|❌|✅|✅|✅|✅|✅|
-|EAC3<sup>3/sup>|✅|✅|✅|✅|✅|✅|✅|
+|EAC3<sup>3</sup>|✅|✅|✅|✅|✅|✅|✅|
 |VORBIS|❌|✅|✅|✅|✅|✅|✅|
 |DTS<sup>4</sup>|❌|❌|❌|✅|✅|✅|✅|
 
@@ -57,7 +57,7 @@ FLAC|✅|❌|✅|✅|✅|✅|✅|
 
 ## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
 
-Subtiles can be a subtle issue for transcoding. Containers have a limited number of subtitles that are supported. If subtitles need to be transcoded, it will happen one of two ways. They can be converted into another supported format (text-based subtitles) or burned into the video (image/lossless based and ASS based) due to the subtitles transcoding not being supported. This is the most intenstive method of transcoding due to two transcodings happening at once; applying the subtitle layer on top of the video layer. 
+Subtiles can be a subtle issue for transcoding. Containers have a limited number of subtitles that are supported. If subtitles need to be transcoded, it will happen one of two ways. They can be converted into another supported format (text-based subtitles) or burned into the video (image/lossless based and ASS based) due to the subtitles transcoding not being supported. This is the most intenstive method of transcoding due to two transcodings happening at once; applying the subtitle layer on top of the video layer.
 
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
@@ -69,7 +69,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |PGSSUB|Picture|❌|❌|✅|❌|
 
 
-<sup>1</sup>ASS Subtitles are only supported by mkv files. MKV files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of Jellyfin.
+<sup>1</sup>ASS Subtitles are only supported by MKV files. MKV files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of Jellyfin.
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
@@ -86,4 +86,4 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 <sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in Firefox and will remux.
 
-<sup>3</sup>MKV containers are improperly labeled as webM in Firefox during playback. 
+<sup>3</sup>MKV containers are improperly labeled as webM in Firefox during playback.

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -1,26 +1,51 @@
 ---
 uid: codecs
-title: Client Compatibility
+title: Codec Compatibility
 ---
 
+ # [Codec Tables](https://en.wikipedia.org/wiki/List_of_codecs "Wikipedia's list of all codecs")
+## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 
-# Video Codec Compatibility
+If the video codec is unsupported, this will result in transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
+
+||WebOS|Android|AndroidTV|Kodi|Roku|
+|:---:|:---:|:---:|:---:|:---:|:---:|
+|[H.262/Xvid](https://en.wikipedia.org/wiki/MPEG-4_Part_2)|✅|✅|✅|✅|✅|
+|[H.262/DivX](https://en.wikipedia.org/wiki/DivX)|✅|✅|✅|✅|✅|
+|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅|
+|[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌<sup>1</sup>|🔶<sup>2</sup>|❌|✅|❌|
+
+<sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
+
+<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
+
+## [Audio Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Audio_coding_formats_support "Wikipedia's audio codec tables")
+
+If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video coding.
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
-|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅
-|[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|🔶<sup>1</sup>|❌|✅|❌
+|MP3|🔶<sup>1</sup>|✅|✅|✅|✅
+|AAC|✅|✅|✅|✅|✅
+|AC3|✅|✅|✅|✅|✅
 
-<sup>1</sup>Android playback is currently broken. Client reports that h265 is supported and attempts to Directstream it.
+<sup>1</sup>MP3 Mono is incorrectly reported as unsupported.
 
-# Audio Codec Compatibility
+## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
+
+Subtiles can be a subtle issue for transcoding. Containers have a limited number of subtitles that are supported. If subtitles need to be transcoded, it will happen one of two ways. They can be converted into another supported format (text-based subtitles) or burned into the video (image/lossless based and ASS based) due to the subtitles transcoding not being supported. This is the most intenstive method of transcoding due to two transcodings happening at once; applying the subtitle layer on top of the video layer. 
+
+## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
+
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process, remuxing speed can be up to 10000x real time, remuxing + audio (ac3 2ch to aac 2ch) happened at 100x real time on the same sample.
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
-|MP3|✅|✅|✅|✅|✅
+|[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|✅|✅|✅|✅|✅
+|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>1, 2</sup>|🔶|🔶|🔶|🔶|🔶
+|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
 
-# Container Compatibility
 
-||WebOS|Android|AndroidTV|Kodi|Roku
-|:---:|:---:|:---:|:---:|:---:|:---:
-|mp4|✅|✅|✅|✅|✅
+<sup>1</sup>MKV containers can hold nearly any codec. *support not verified, initial testing is showing that all containers convert to ts using hls streaming protocol*
+
+<sup>2</sup>webm containers that have file extension mkv are marked as mkv on the media info page, and properly labeled as webm during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -11,13 +11,14 @@ The goal is to Direct Play all media. This means the container, video, audio and
 
 [Breakdown of video codecs.](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)
 
-||Chrome|Firefox|Safari|Android|iOS|AndroidTV|Kodi|[Roku](https://developer.roku.com/docs/specs/streaming.md)|
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-|[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌||❌|✅||
-|[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌||❌|✅||
-|[H.264 8Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅||✅|✅||
-|[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅||✅|✅||
-|[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>||❌|✅||
+||Chrome|Firefox|Safari|Android|iOS|AndroidTV|[Roku](https://developer.roku.com/docs/specs/streaming.md)|Kodi|[MPV Shim](https://jellyfin.org/docs/general/clients/index.html#jellyfin-mpv-shim)|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌||❌||✅|✅|
+|[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌||❌||✅|✅|
+|[H.264 8Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅||✅||✅|✅|
+|[H.264 10Bit](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|❌|❌|✅||✅||✅|✅|
+|[H.265](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|❌|❌<sup>1</sup>|🔶<sup>2</sup>||❌||✅|✅|
+|[VP9](https://caniuse.com/#search=vp9 "V9 Browser Support Reference")|✅|✅|❌|||||||
 
 <sup>1</sup>HEVC support is potentially available by offloading to the operating system, but this has not been tested.
 
@@ -39,21 +40,21 @@ The goal is to Direct Play all media. This means the container, video, audio and
 
 If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video coding.
 
-||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Kodi|Roku|
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-FLAC|✅|❌|✅|✅|||✅||
-|MP3|🔶<sup>1</sup>|🔶|✅|✅|||✅||
-|AAC|🔶<sup>2</sup>|🔶|✅|✅|||✅||
-|AC3|✅|❌|✅|✅|||✅||
-|EAC3<sup>3</sup>|✅|✅|✅|✅|||✅||
-|VORBIS|❌|✅|✅|✅|||✅||
-|DTS<sup>4</sup>|❌|❌|❌|✅|||✅||
+||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Roku|Kodi|MPV Shim|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|FLAC|✅|❌|✅|✅||||✅|✅|
+|MP3|🔶<sup>1</sup>|🔶|✅|✅||||✅|✅|
+|AAC|✅|✅|✅|✅||||✅|✅|
+|AC3|✅|❌|✅|✅||||✅|✅|
+|EAC3<sup>2</sup>|✅|✅|✅|✅||||✅|✅|
+|VORBIS<sup>3</sup>|✅|✅|✅|✅||||✅|✅|
+|DTS<sup>4</sup>|❌|❌|❌|✅||||✅|✅|
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
-<sup>2</sup>AAC is incorrectly reported as unsupported and will transcode to MP3.
+<sup>2</sup>Only EAC3 2.0 has been tested.
 
-<sup>3</sup>Only EAC3 2.0 has been tested.
+<sup>3</sup>OGG containers are not supported and will cause VORBIS to convert.
 
 <sup>4</sup>Only DTS Mono has been tested.
 
@@ -63,15 +64,17 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
-|SubRip Text (SRT)|Text|❌|🔶|✅|🔶|
+|[SubRip Text (SRT)](https://en.wikipedia.org/wiki/SubRip)|Text|❌|🔶|✅|🔶|
+|[WebVTT (VTT)](https://en.wikipedia.org/wiki/WebVTT)|Text|❌<sup>1</sup>|❌<sup>1</sup>|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
-|DVB-SUB [(SUB + IDX)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
+|DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
 |PGSSUB|Picture|❌|❌|✅|❌|
 
+<sup>1</sup>VTT are supported in an [HLS Stream](https://helpx.adobe.com/adobe-media-server/dev/webvtt-subtitles-captions.html).
 
-<sup>1</sup>ASS Subtitles are only supported by MKV files. MKV files aren't supported by Firefox. They will always inherently be burned into the video. This is not a limitation of Jellyfin.
+<sup>2</sup>ASS Subtitles are only supported by MKV files. MKV files aren't supported by Firefox. They will always inherently be burned into the video. This is not a limitation of Jellyfin.
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
@@ -81,8 +84,9 @@ If the container is unsupported, this will result in remuxing. The video and aud
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 |[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅|✅|✅|
 |[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|✅|❌||✅|✅|✅||
-|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|✅|||||✅||
+|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|✅|✅||||✅||
 |[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>4</sup>|✅|✅|✅|✅|✅|✅|✅|
+|[OGG](https://en.wikipedia.org/wiki/Ogg)|❌|❌|❌|❌|❌|❌|❌|
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -67,4 +67,4 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 <sup>2</sup>MKV containers can hold nearly any codec, but are not compatible with streaming in browsers and will remux.
 
-<sup>3</sup>webm containers that have file extension mkv are marked as mkv on the media info page, and properly labeled as webm during playback. 
+<sup>3</sup>mkv containers are improperly labeled as webm during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -42,10 +42,10 @@ If the container is unsupported, this will result in remuxing. The video and aud
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
 |[mp4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)|✅|✅|✅|✅|✅
-|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>1, 2</sup>|🔶|🔶|🔶|🔶|🔶
-|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|✅|✅|✅|✅|✅
+|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>1, 2</sup>|❌|🔶|🔶|🔶|🔶
+|[ts](https://en.wikipedia.org/wiki/MPEG_transport_stream)|❌|✅|✅|✅|✅
 
 
-<sup>1</sup>MKV containers can hold nearly any codec. *support not verified, initial testing is showing that all containers convert to ts using hls streaming protocol*
+<sup>1</sup>MKV containers can hold nearly any codec. *support not verified, initial testing is showing that all containers convert to ts using hls streaming protocol* Mp4 successfully streamed using http protocol instead of hls protocol and did not remux.
 
 <sup>2</sup>webm containers that have file extension mkv are marked as mkv on the media info page, and properly labeled as webm during playback. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -8,10 +8,10 @@ title: Client Compatibility
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:
-|H264/AVC|✅|✅|✅|✅|✅
-H265/HEVC|❌|🔶<sup>1</sup>|❌|✅|❌
+|[H.264/AVC](https://caniuse.com/#feat=mpeg4 "H264 Browser Support Reference")|✅|✅|✅|✅|✅
+|[H.265/HEVC](https://caniuse.com/#feat=hevc "HEVC Browser Support Reference")|❌|🔶<sup>1</sup>|❌|✅|❌
 
-<sup>1</sup>:Android playback is currently broken. Client reports that h265 is supported and attempts to Directstream it.
+<sup>1</sup>Android playback is currently broken. Client reports that h265 is supported and attempts to Directstream it.
 
 # Audio Codec Compatibility
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -69,7 +69,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |PGSSUB|Picture|❌|❌|✅|❌|
 
 
-<sup>1</sup>ASS Subtitles are only supported by MKV files. MKV files aren't supported by Firefox.They will always inherently be burned into the video. This is not a limitation of Jellyfin.
+<sup>1</sup>ASS Subtitles are only supported by MKV files. MKV files aren't supported by Firefox. They will always inherently be burned into the video. This is not a limitation of Jellyfin.
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -66,7 +66,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 |SubRip Text (SRT)|Text|❌|🔶|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
-|DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
+|DVB-SUB [(SUB + IDX)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|
 |MP4TT/TXTT|XML|❌|✅|❌|❌|
 |PGSSUB|Picture|❌|❌|✅|❌|
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -49,7 +49,7 @@ FLAC|✅|❌|✅|✅|✅|✅|✅|
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
-<sup>2</sup> AAC is incorrectly reported as unsupported and will transcode to MP3.
+<sup>2</sup>AAC is incorrectly reported as unsupported and will transcode to MP3.
 
 <sup>3</sup>Only EAC3 2.0 has been tested.
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -1,0 +1,26 @@
+---
+uid: codecs
+title: Client Compatibility
+---
+
+
+# Video Codec Compatibility
+
+||WebOS|Android|AndroidTV|Kodi|Roku
+|:---:|:---:|:---:|:---:|:---:|:---:
+|H264/AVC|✅|✅|✅|✅|✅
+H265/HEVC|❌|🔶<sup>1</sup>|❌|✅|❌
+
+<sup>1</sup>:Android playback is currently broken. Client reports that h265 is supported and attempts to Directstream it.
+
+# Audio Codec Compatibility
+
+||WebOS|Android|AndroidTV|Kodi|Roku
+|:---:|:---:|:---:|:---:|:---:|:---:
+|MP3|✅|✅|✅|✅|✅
+
+# Container Compatibility
+
+||WebOS|Android|AndroidTV|Kodi|Roku
+|:---:|:---:|:---:|:---:|:---:|:---:
+|mp4|✅|✅|✅|✅|✅

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -19,7 +19,7 @@ title: Codec Compatibility
 
 <sup>1</sup>HEVC support is potentially possible by offloading to the OS. *untested*
 
-<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Directstream it.
+<sup>2</sup>Android playback is currently broken. Client reports that HEVC is supported and attempts to Direct Stream.
 
 [Format Cheetsheet:](https://en.wikipedia.org/wiki/MPEG-4#MPEG-4_Parts)
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -61,7 +61,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ||Format|TS|MP4|MKV|AVI|
 |:---:|:---:|:---:|:---:|:---:|:---:|
-|SubRip Text (.srt)|Text|❌|🔶|✅|🔶|
+|SubRip Text (SRT)|Text|❌|🔶|✅|🔶|
 |ASS/SSA<sup>1</sup>|Formatted Text|❌|❌|✅|🔶|
 |VobSub|Picture|❌|✅|✅|🔶|
 |DVB-SUB [(.sub/.idx)](https://forum.videohelp.com/threads/261451-Difference-between-SUB-and-IDX-file)|Picture|✅|❌|✅|❌|

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -73,7 +73,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
-If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a Rpi3.
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a RPi3.
 
 ||Browser|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -73,7 +73,7 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
-If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a RPi3.
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a supported container. This is the least intensive process. Most video containers will be remuxed to use the HLS streaming protocol and TS containers. Remuxing shouldn't be a concern even for an RPi3.
 
 ||Browser|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -53,7 +53,7 @@ FLAC|✅|❌|✅|✅|✅|✅|✅|
 
 <sup>3</sup>Only EAC3 2.0 has been tested.
 
-<sup>4</sup> Only DTS Mono has been tested.
+<sup>4</sup>Only DTS Mono has been tested.
 
 ## [Subtitle Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats#Subtitle/caption_formats_support "Wikipedia's subtitle codec tables")
 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -41,13 +41,13 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 
 ||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Kodi|Roku|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-FLAC|✅|❌|✅|✅||✅|✅||
-|MP3|🔶<sup>1</sup>|🔶|✅|✅||✅|✅||
-|AAC|🔶<sup>2</sup>|🔶|✅|✅||✅|✅||
-|AC3|✅|❌|✅|✅||✅|✅||
-|EAC3<sup>3</sup>|✅|✅|✅|✅||✅|✅||
-|VORBIS|❌|✅|✅|✅||✅|✅||
-|DTS<sup>4</sup>|❌|❌|❌|✅||✅|✅||
+FLAC|✅|❌|✅|✅|||✅||
+|MP3|🔶<sup>1</sup>|🔶|✅|✅|||✅||
+|AAC|🔶<sup>2</sup>|🔶|✅|✅|||✅||
+|AC3|✅|❌|✅|✅|||✅||
+|EAC3<sup>3</sup>|✅|✅|✅|✅|||✅||
+|VORBIS|❌|✅|✅|✅|||✅||
+|DTS<sup>4</sup>|❌|❌|❌|✅|||✅||
 
 <sup>1</sup>MP3 Mono is incorrectly reported as unsupported and will transcode to AAC.
 
@@ -77,12 +77,12 @@ Subtiles can be a subtle issue for transcoding. Containers have a limited number
 
 If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a supported container. This is the least intensive process. Most video containers will be remuxed to use the HLS streaming protocol and TS containers. Remuxing shouldn't be a concern even for an RPi3.
 
-||Browser|Android|AndroidTV|Kodi|Roku
-|:---:|:---:|:---:|:---:|:---:|:---:
-|[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅
-|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|❌|✅|🔶|✅|🔶
-|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|✅||||
-|[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>4</sup>|✅|✅|✅|✅|✅
+||Chrome|Firefox|Safari|Android|AndroidTV|Kodi|Roku|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|[MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14)<sup>1</sup>|✅|✅|✅|✅|✅|✅|✅|
+|[MKV](https://en.wikipedia.org/wiki/Matroska)<sup>2, 3</sup>|✅|❌||✅|✅|✅||
+|[WebM](https://en.wikipedia.org/wiki/WebM)<sup>3</sup>|✅|||||✅||
+|[TS](https://en.wikipedia.org/wiki/MPEG_transport_stream)<sup>4</sup>|✅|✅|✅|✅|✅|✅|✅|
 
 <sup>1</sup>MP4 containers are one of the few containers that will not remux.
 
@@ -90,4 +90,4 @@ If the container is unsupported, this will result in remuxing. The video and aud
 
 <sup>3</sup>MKV containers are improperly labeled as WebM in Firefox during playback.
 
-<sup>4</sup>TS is one of the primary containers for streaming using Jellyfin. 
+<sup>4</sup>TS is one of the primary containers for streaming for Jellyfin. 

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -55,7 +55,7 @@ Note: ASS Subtitles are only supported by mkv files. Mkv files can't natively be
 
 ## [Container Compatibility](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers)
 
-If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a Rpi3.
+If the container is unsupported, this will result in remuxing. The video and audio codec will remain intact, but wrapped in a container that is supported. This is the least intensive process. Most video containers will be remuxed to use the hls streaming protocol and ts containers. Remuxing shouldn't be a concern even for a RPi3.
 
 ||WebOS|Android|AndroidTV|Kodi|Roku
 |:---:|:---:|:---:|:---:|:---:|:---:

--- a/general/clients/codecs.md
+++ b/general/clients/codecs.md
@@ -5,7 +5,7 @@ title: Codec Compatibility
 
  # [Codec Tables](https://en.wikipedia.org/wiki/List_of_codecs "Wikipedia's list of all codecs")
  
- The goal is to DirectPlay all media. This means the container, video, audio and subtitles are all compatible with the client. DirectStream will occur if the audio, container or subtitles happen to not be supported. Subtitles can be tricky because they can cause DirectStreaming (subtitles are remuxed) or video transcoding (burning in subtitles) to occur. If the video codec is unsupported, this will result in video transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
+ The goal is to Direct Play all media. This means the container, video, audio and subtitles are all compatible with the client. Direct Stream will occur if the audio, container or subtitles happen to not be supported. Subtitles can be tricky because they can cause Direct Stream (subtitles are remuxed) or video transcoding (burning in subtitles) to occur. If the video codec is unsupported, this will result in video transcoding. This is the most intensive CPU component of transcoding. Decoding is less intensive than encoding.
  
 ## [Video Compatibility](https://en.wikipedia.org/wiki/Comparison_of_video_container_formats "Wikipedia's video codec tables")
 


### PR DESCRIPTION
Initial skeleton page for codecs. Requires verification and deep dive research into each profile for each codec. Pushing now to test website layout.

[My upstream branch](https://github.com/Artiume/jellyfin-docs/blob/master/general/clients/codecs.md) 