### PR TITLE
Improve mopidy plugin documentation

### DIFF
--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -208,13 +208,14 @@ The official Jellyfin WebOS app.
 
 ### Mopidy-Jellyfin
 
-A third party plugin for Mopidy that uses Jellyfin as a backend.
+An official plugin for Mopidy that uses Jellyfin as a backend.
 
-**Status:** ⭐ Active, 3rd-Party
+**Status:** ⭐ Active
 
 **Links:**
 
 * [GitHub](https://github.com/mcarlton00/mopidy-jellyfin)
+* [Installing](xref:clients-installing-mopidy)
 
 ## Roku
 

--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -191,6 +191,7 @@ The official Jellyfin Kodi plugin.
 **Links:**
 
 * [GitHub](https://github.com/jellyfin/jellyfin-kodi)
+* [Installing](xref:clients-installing-kodi)
 
 ## LG WebOS
 

--- a/general/clients/installing-mopidy.md
+++ b/general/clients/installing-mopidy.md
@@ -19,6 +19,8 @@ For general use computers, such as workstations or laptops, it's recommended to 
 3. Configure your `mopidy.conf` located at `$HOME/.config/mopidy/mopidy.conf`  
     See [Config File](xref:clients-installing-mopidy#config-file)
 4. There may be a need to install extra gstreamer codecs if they're not already on your system, but these are highly variable and depend on your hardware and distro
+5. Start the program by running `mopidy` from a terminal
+6. See [Usage](xref:clients-installing-mopidy#usage)
 
 ## Raspberry Pi (Remote Controlled Speakers)
 
@@ -35,6 +37,7 @@ Utilizing a Raspberry Pi (or other small form factor computer) it's possible to 
     See [Config File](xref:clients-installing-mopidy#config-file)
 7. Enable and start the mopidy service:  
     `sudo systemctl enable --now mopidy`
+8. See [Usage](xref:clients-installing-mopidy#usage)
 
 ## Config File
 
@@ -59,10 +62,18 @@ Other options that may be useful to include:
 enabled = true
 # Useful if you want to control this instance from a remote mpd client
 hostname = 0.0.0.0
+port = 6600
 # If you have artists or folders with large amounts of files, this helps avoid timeout errors
 connection_timeout = 300
 
 # Used in the event you want to control this system from a web browser
 [http]
 hostname = 0.0.0.0
+port = 6680
 ```
+
+Be aware that Mopidy provides no security on open ports, so if you'll be running this in a public place you'll likely want to change `0.0.0.0` to `127.0.0.1` to prevent somebody else hijacking your listening sesion.
+
+## Usage
+
+Once Mopidy is running, you can connect and control it with your client of choice.  MPD clients will connect using port 6600 by default.  Tested MPD clients include [ncmpcpp](https://github.com/arybczak/ncmpcpp) and [M.A.L.P](https://play.google.com/store/apps/details?id=org.gateshipone.malp).  Web clients can be reached at `http://localhost:6680`, or `http://$IP_ADDRESS:6680` if this is a remote system.

--- a/general/clients/installing-mopidy.md
+++ b/general/clients/installing-mopidy.md
@@ -11,7 +11,7 @@ The Mopidy Jellyfin plugin is available to install from [PyPi](https://pypi.org/
 
 For general use computers, such as workstations or laptops, it's recommended to install Mopidy plugins in user mode.  Installing python packages from pip using sudo or root permissions can lead to conflicts with your package manager in the future.
 
-1. Install Mopidy using your method of choice using the [official docs](https://docs.mopidy.com/en/latest/installation/)
+1. Install Mopidy using your method of choice using the [official documentation](https://docs.mopidy.com/en/latest/installation/)
 1. Install the Jellyfin plugin for Mopidy:  
     `pip3 install --user mopidy-jellyfin`
 2. (Optional) Install other mopidy related packages:  
@@ -27,7 +27,7 @@ For general use computers, such as workstations or laptops, it's recommended to 
 Utilizing a Raspberry Pi (or other small form factor computer) it's possible to use Mopidy to build a set of standalone smart speakers connected to your Jellyfin server.
 
 1. Grab the latest [raspbian image](https://www.raspberrypi.org/downloads/raspbian/).  Unless you have a need for a GUI, the 'Lite' image is plenty for this project.
-2. Install the image to the sd card (See the [official docs](https://www.raspberrypi.org/documentation/installation/installing-images/README.md))
+2. Install the image to the SD card (See the [official documentation](https://www.raspberrypi.org/documentation/installation/installing-images/README.md))
 3. Install Mopidy from their [apt repo](https://docs.mopidy.com/en/latest/installation/debian/#install-from-apt-mopidy-com) to ensure we get the latest version
 4. Install required OS packages:  
     `sudo apt install mopidy mopidy-mpd gstreamer1.0-plugins-bad python3-pip`
@@ -41,7 +41,7 @@ Utilizing a Raspberry Pi (or other small form factor computer) it's possible to 
 
 ## Config File
 
-The config file for mopidy is divided into sections in an ini format.  An example Jellyfin example is shown here.
+The config file for mopidy is divided into sections in an INI format.  An example for Jellyfin is shown here.
 
 ```ini
 [jellyfin]
@@ -60,10 +60,10 @@ Other options that may be useful to include:
 ```ini
 [mpd]
 enabled = true
-# Useful if you want to control this instance from a remote mpd client
+# Useful if you want to control this instance from a remote MPD client
 hostname = 0.0.0.0
 port = 6600
-# If you have artists or folders with large amounts of files, this helps avoid timeout errors
+# This will help avoid timeout errors for  artists or folders with large amounts of files
 connection_timeout = 300
 
 # Used in the event you want to control this system from a web browser
@@ -72,7 +72,7 @@ hostname = 0.0.0.0
 port = 6680
 ```
 
-Be aware that Mopidy provides no security on open ports, so if you'll be running this in a public place you'll likely want to change `0.0.0.0` to `127.0.0.1` to prevent somebody else hijacking your listening sesion.
+Be aware that Mopidy provides no security on open ports, so if you'll be running this in a public place you'll likely want to change `0.0.0.0` to `127.0.0.1` to prevent somebody else from hijacking your listening session.
 
 ## Usage
 

--- a/general/clients/installing-mopidy.md
+++ b/general/clients/installing-mopidy.md
@@ -1,0 +1,66 @@
+---
+uid: clients-installing-mopidy
+title: Installing Mopidy Plugin
+---
+
+# Installing Mopidy Plugin
+
+The Mopidy Jellyfin plugin is available to install from [PyPi](https://pypi.org/project/Mopidy-Jellyfin) using pip.
+
+## General
+
+For general use computers, such as workstations or laptops, it's recommended to install Mopidy plugins in user mode.  Installing python packages from pip using sudo or root permissions can lead to conflicts with your package manager in the future.
+
+1. Install Mopidy using your method of choice using the [official docs](https://docs.mopidy.com/en/latest/installation/)
+2. Install the Jellyfin plugin for Mopidy
+    * `pip3 install --user mopidy-jellyfin`
+3. (Optional) Install other mopidy related packages
+    * `pip3 install --user mopidy-mpd mopidy-musicbox-webclient`
+4. Configure your `mopidy.conf` located at `$HOME/.config/mopidy/mopidy.conf`
+  * See [Config File](xref:clients-installing-mopidy#config-file)
+5. There may be a need to install extra gstreamer codecs if they're not already on your system, but these are highly variable and depend on your hardware and distro
+
+## Raspberry Pi (Remote Controlled Speakers)
+
+Utilizing a Raspberry Pi (or other small form factor computer) it's possible to use Mopidy to build a set of standalone smart speakers connected to your Jellyfin server.
+
+1. Grab the latest [raspbian image](https://www.raspberrypi.org/downloads/raspbian/).  Unless you have a need for a GUI, the 'Lite' image is plenty for this project.
+2. Install the image to the sd card (See the [official docs](https://www.raspberrypi.org/documentation/installation/installing-images/README.md))
+3. Install Mopidy from their [apt repo](https://docs.mopidy.com/en/latest/installation/debian/#install-from-apt-mopidy-com) to ensure we get the latest version
+4. Install required OS packages
+    * `sudo apt install mopidy mopidy-mpd gstreamer1.0-plugins-bad python3-pip`
+5. Install the Jellyfin plugin and any other Mopidy related packages you may want
+    * `sudo pip3 install mopidy-jellyfin mopidy-musicbox-webclient`
+6. Configure your `mopidy.conf` located at `/etc/mopidy/mopidy.conf`
+    * See [Config File](xref:clients-installing-mopidy#config-file)
+7. Enable and start the mopidy service
+    * `sudo systemctl enable --now mopidy`
+
+## Config File
+
+The config file for mopidy is divided into sections in an ini format.  An example Jellyfin example is shown here.
+```
+[jellyfin]
+hostname = Jellyfin server hostname
+port = Jellyfin server port
+username = username
+password = password
+libraries = Library1, Library2 (Optional: will default to "Music" if left undefined)
+```
+
+The `libraries` option determines what is populated into Mopidy's internal library.  All of your audio libraries will be available from the browse menu regardless of what is entered here.
+
+Other options that may be useful to include:
+
+```
+[mpd]
+enabled = true
+# Useful if you want to control this instance from a remote mpd client
+hostname = 0.0.0.0
+# If you have artists or folders with large amounts of files, this helps avoid timeout errors
+connection_timeout = 300
+
+# Used in the event you want to control this system from a web browser
+[http]
+hostname = 0.0.0.0
+```

--- a/general/clients/installing-mopidy.md
+++ b/general/clients/installing-mopidy.md
@@ -77,3 +77,10 @@ Be aware that Mopidy provides no security on open ports, so if you'll be running
 ## Usage
 
 Once Mopidy is running, you can connect and control it with your client of choice.  MPD clients will connect using port 6600 by default.  Tested MPD clients include [ncmpcpp](https://github.com/arybczak/ncmpcpp) and [M.A.L.P](https://play.google.com/store/apps/details?id=org.gateshipone.malp).  Web clients can be reached at `http://localhost:6680`, or `http://$IP_ADDRESS:6680` if this is a remote system.
+
+## Upgrading
+
+When a new version of Mopidy Jellyfin is released, you can upgrade via pip using the `--upgrade` flag.  Using the install examples from above:  
+    `pip3 install --user --upgrade mopidy-jellyfin`  
+or  
+    `sudo pip3 install --upgrade mopidy-jellyfin`

--- a/general/clients/installing-mopidy.md
+++ b/general/clients/installing-mopidy.md
@@ -12,13 +12,13 @@ The Mopidy Jellyfin plugin is available to install from [PyPi](https://pypi.org/
 For general use computers, such as workstations or laptops, it's recommended to install Mopidy plugins in user mode.  Installing python packages from pip using sudo or root permissions can lead to conflicts with your package manager in the future.
 
 1. Install Mopidy using your method of choice using the [official docs](https://docs.mopidy.com/en/latest/installation/)
-2. Install the Jellyfin plugin for Mopidy
-    * `pip3 install --user mopidy-jellyfin`
-3. (Optional) Install other mopidy related packages
-    * `pip3 install --user mopidy-mpd mopidy-musicbox-webclient`
-4. Configure your `mopidy.conf` located at `$HOME/.config/mopidy/mopidy.conf`
-  * See [Config File](xref:clients-installing-mopidy#config-file)
-5. There may be a need to install extra gstreamer codecs if they're not already on your system, but these are highly variable and depend on your hardware and distro
+1. Install the Jellyfin plugin for Mopidy:  
+    `pip3 install --user mopidy-jellyfin`
+2. (Optional) Install other mopidy related packages:  
+    `pip3 install --user mopidy-mpd mopidy-musicbox-webclient`
+3. Configure your `mopidy.conf` located at `$HOME/.config/mopidy/mopidy.conf`  
+    See [Config File](xref:clients-installing-mopidy#config-file)
+4. There may be a need to install extra gstreamer codecs if they're not already on your system, but these are highly variable and depend on your hardware and distro
 
 ## Raspberry Pi (Remote Controlled Speakers)
 
@@ -27,32 +27,34 @@ Utilizing a Raspberry Pi (or other small form factor computer) it's possible to 
 1. Grab the latest [raspbian image](https://www.raspberrypi.org/downloads/raspbian/).  Unless you have a need for a GUI, the 'Lite' image is plenty for this project.
 2. Install the image to the sd card (See the [official docs](https://www.raspberrypi.org/documentation/installation/installing-images/README.md))
 3. Install Mopidy from their [apt repo](https://docs.mopidy.com/en/latest/installation/debian/#install-from-apt-mopidy-com) to ensure we get the latest version
-4. Install required OS packages
-    * `sudo apt install mopidy mopidy-mpd gstreamer1.0-plugins-bad python3-pip`
-5. Install the Jellyfin plugin and any other Mopidy related packages you may want
-    * `sudo pip3 install mopidy-jellyfin mopidy-musicbox-webclient`
-6. Configure your `mopidy.conf` located at `/etc/mopidy/mopidy.conf`
-    * See [Config File](xref:clients-installing-mopidy#config-file)
-7. Enable and start the mopidy service
-    * `sudo systemctl enable --now mopidy`
+4. Install required OS packages:  
+    `sudo apt install mopidy mopidy-mpd gstreamer1.0-plugins-bad python3-pip`
+5. Install the Jellyfin plugin and any other Mopidy related packages you may want:  
+    `sudo pip3 install mopidy-jellyfin mopidy-musicbox-webclient`
+6. Configure your `mopidy.conf` located at `/etc/mopidy/mopidy.conf`:  
+    See [Config File](xref:clients-installing-mopidy#config-file)
+7. Enable and start the mopidy service:  
+    `sudo systemctl enable --now mopidy`
 
 ## Config File
 
 The config file for mopidy is divided into sections in an ini format.  An example Jellyfin example is shown here.
-```
+
+```ini
 [jellyfin]
 hostname = Jellyfin server hostname
 port = Jellyfin server port
 username = username
 password = password
-libraries = Library1, Library2 (Optional: will default to "Music" if left undefined)
+# Optional: will default to "Music" if left undefined
+libraries = Library1, Library2
 ```
 
 The `libraries` option determines what is populated into Mopidy's internal library.  All of your audio libraries will be available from the browse menu regardless of what is entered here.
 
 Other options that may be useful to include:
 
-```
+```ini
 [mpd]
 enabled = true
 # Useful if you want to control this instance from a remote mpd client

--- a/general/toc.yml
+++ b/general/toc.yml
@@ -2,6 +2,7 @@
   items:
   - uid: codec-support
   - uid: clients-installing-kodi
+  - uid: clients-installing-mopidy
 
 - name: Administration
   items:


### PR DESCRIPTION
Adds installation instructions for the mopidy plugin.  Also changes client page to respect that it's now an official client.