### PR TITLE
Add port 7359 for client discovery

### DIFF
--- a/general/administration/connectivity.md
+++ b/general/administration/connectivity.md
@@ -47,6 +47,10 @@ This setting can also be modified from the **Networking** page to use a differen
 
 Since client auto-discover would break if this option were configurable, you cannot change this in the settings at this time.
 
+**Client Discovery:** 7359 UDP
+
+Allows clients to discover the Jellyfin Server on the local network.  A broadcast message to this port with `Who is JellyfinServer?` will get a json response that includes the server Address, ID and Name.
+
 ## Dynamic Ports
 
 Live TV devices will often use a random UDP port for HD Homerun devices. The server will select an unused port on startup to connect to these tuner devices.


### PR DESCRIPTION
See here: https://github.com/MediaBrowser/Emby/wiki/Locating-the-Server
And: https://github.com/jellyfin/jellyfin/blob/3ab979c6ba6351c2c0cf2bd2030de2c1e6bdc92e/Emby.Server.Implementations/Udp/UdpServer.cs#L101