### PR TITLE
Update nginx subpath with baseurl instructions

### DIFF
--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -157,7 +157,7 @@ server {
 #    }
 #    location /socket {
 #        # Proxy Jellyfin Websockets traffic
-#        proxy_pass http://SERVER_IP_ADDRESS:8096/;
+#        proxy_pass http://SERVER_IP_ADDRESS:8096/socket;
 #        proxy_http_version 1.1;
 #        proxy_set_header Upgrade $http_upgrade;
 #        proxy_set_header Connection "upgrade";

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -173,8 +173,9 @@ server {
 
 ## Nginx with subpath
 
-When connecting to server from a client application, enter ``http(s)://DOMAIN_NAME/jellyfin`` in the address field, and **clear the port field**.
-Not all clients may handle this properly, but this is currently working for the web and Android clients.
+When connecting to server from a client application, enter ``http(s)://DOMAIN_NAME/jellyfin`` in the address field.
+
+Set the base URL field in the Jellyfin server.  This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the Jellyfin Web UI.  Fill in this box with `/jellyfin` and click Save.  The server will need to be restarted before this change takes effect.
 
 ```
 # Jellyfin hosted on http(s)://DOMAIN_NAME/jellyfin
@@ -197,13 +198,8 @@ server {
 
     # Jellyfin
     location /jellyfin {
-        return 302 $scheme://$host/jellyfin/;
-    }
-
-    location /jellyfin/ {
         # Proxy main Jellyfin traffic
-        # The / at the end is significant.
-        proxy_pass http://SERVER_IP_ADDRESS:8096/;
+        proxy_pass http://SERVER_IP_ADDRESS:8096;
 
         proxy_pass_request_headers on;
 

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -197,7 +197,7 @@ server {
     }
 
     # Jellyfin
-    location /jellyfin {
+    location /jellyfin/ {
         # Proxy main Jellyfin traffic
         proxy_pass http://SERVER_IP_ADDRESS:8096/jellyfin/;
 

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -197,7 +197,7 @@ server {
     }
 
     # Jellyfin
-    location /jellyfin/ {
+    location /jellyfin {
         return 302 $scheme://$host/jellyfin/;
     }
 

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -198,7 +198,15 @@ server {
 
     # Jellyfin
     location /jellyfin/ {
+        return 302 $scheme://$host/jellyfin/;
+    }
+
+    location /jellyfin/ {
         # Proxy main Jellyfin traffic
+
+        # The / at the end is significant.
+        # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
+
         proxy_pass http://SERVER_IP_ADDRESS:8096/jellyfin/;
 
         proxy_pass_request_headers on;

--- a/general/administration/reverse-proxy.md
+++ b/general/administration/reverse-proxy.md
@@ -144,7 +144,7 @@ server {
 #
 #    location / {
 #        # Proxy main Jellyfin traffic
-#        proxy_pass http://SERVER_IP_ADDRESS:8096;
+#        proxy_pass http://SERVER_IP_ADDRESS:8096/;
 #        proxy_set_header Host $host;
 #        proxy_set_header X-Real-IP $remote_addr;
 #        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -157,7 +157,7 @@ server {
 #    }
 #    location /socket {
 #        # Proxy Jellyfin Websockets traffic
-#        proxy_pass http://SERVER_IP_ADDRESS:8096;
+#        proxy_pass http://SERVER_IP_ADDRESS:8096/;
 #        proxy_http_version 1.1;
 #        proxy_set_header Upgrade $http_upgrade;
 #        proxy_set_header Connection "upgrade";
@@ -199,7 +199,7 @@ server {
     # Jellyfin
     location /jellyfin {
         # Proxy main Jellyfin traffic
-        proxy_pass http://SERVER_IP_ADDRESS:8096;
+        proxy_pass http://SERVER_IP_ADDRESS:8096/jellyfin/;
 
         proxy_pass_request_headers on;
 


### PR DESCRIPTION
In the event a user wants to use a subpath, we should recommend using the baseurl so the application is aware that it's running at `/jellyfin` instead of the root