### PR TITLE
Force generated newline on command line examples

### DIFF
--- a/general/contributing/development.md
+++ b/general/contributing/development.md
@@ -34,7 +34,7 @@ The first step is to set up a copy of the Git repository of the project you want
 1. On GitHub, "Fork" the Jellyfin repository you wish to contribute to, to your own user account using the "Fork" button in the relevant repository.
 
 1. Clone your fork to your local machine and enter the directory:  
-    `git clone git@github.com:yourusername/projectname.git`
+    `git clone git@github.com:yourusername/projectname.git`  
     `cd projectname/`
 
 1. Add the "upstream" remote, which allows you to pull down changes from the main project easily:  
@@ -57,7 +57,7 @@ You will now be ready to begin building or modifying the project.
 Once you have your repository, you can get to work.
 
 1. Rebase your local branches against upstream `master` so you are working off the latest changes:  
-    `git fetch --all`
+    `git fetch --all`  
     `git rebase upstream/master`
 
 1. Create a local feature branch off of `master` to make your changes:  
@@ -73,9 +73,9 @@ Once you have your repository, you can get to work.
 1. On GitHub, create a new PR against the upstream `master` branch following the advice below.
 
 1. Once your PR is merged, ensure you keep your local branches up-to-date:  
-    `git fetch --all`
-    `git checkout master`
-    `git rebase upstream/master`
+    `git fetch --all`  
+    `git checkout master`  
+    `git rebase upstream/master`  
     `git push -u origin master`
 
 1. Delete your local feature branch if you no longer need it:
@@ -111,7 +111,7 @@ To test someone else's pull request, you must import the changes to your local r
     `git checkout my-testing-branch`
 
 1. Perform any testing or build required to test, then return to master and delete the branch:
-    `git checkout master`
+    `git checkout master`  
     `git branch -D my-testing-branch`
 
 ## Pull Request Guidelines


### PR DESCRIPTION
Add two trailing spaces behind command line examples to force
generating a newline a.k.a `<BR>`. This prevents joining the
commands in one line and confuse the casual cut&paste user.