### PR TITLE
Contribution Documentation Improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "search.exclude": {
+        "src/**": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repository houses all documentation for Jellyfin available at [jellyfin.org
 
 The site is built with [DocFX](https://dotnet.github.io/docfx/) using [DocFX Flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html). See the content section [here](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html) for a quick tutorial on DocFX.
 
-Since the site is mostly written with simple Markdown files, the easiest and fastest way to contribute is to just edit the source files directory on GitHub. For example, you could edit this README page by going to this link: https://github.com/jellyfin/jellyfin-docs/edit/master/README.md
+Since the site is mostly written with simple Markdown files, the easiest and fastest way to contribute is to just edit the source files directory on GitHub. For example, you could edit this README page by going to its [edit page](https://github.com/jellyfin/jellyfin-docs/edit/master/README.md) on GitHub.
 
 Editing directly on GitHub provides a feature to preview your changes for the current document, but if you want to see your changes within the context of the actual website or make more advanced changes to the site, you will need to run a copy of the site locally.
 
-To run the site locally, you can start by following the instructions to [install DocFx as a command line tool](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Once installed, you can run the following command from the repository root directory:
+To run the site locally, you can start by following the instructions to install DocFx as a [command line tool](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Once installed, you can run the following command from the repository root directory.
 
 ```bash
 docfx --serve
@@ -21,7 +21,7 @@ This will build the site and start up a development server to test out your chan
 
 # Layout
 
-The following sections the documentation content that is available in each area of the site.
+The following sections explain the documentation content available for each area of the site.
 
 ## Plugin API
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,25 @@
 
 This repository houses all documentation for Jellyfin available at [jellyfin.org](https://docs.jellyfin.org/) and written in markdown.
 
+# Contributing
+
+The site is built with [DocFX](https://dotnet.github.io/docfx/) using [DocFX Flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html). See the content section [here](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html) for a quick tutorial on DocFX.
+
+Since the site is mostly written with simple Markdown files, the easiest and fastest way to contribute is to just edit the source files directory on GitHub. For example, you could edit this README page by going to this link: https://github.com/jellyfin/jellyfin-docs/edit/master/README.md
+
+Editing directly on GitHub provides a feature to preview your changes for the current document, but if you want to see your changes within the context of the actual website or make more advanced changes to the site, you will need to run a copy of the site locally.
+
+To run the site locally, you can start by following the instructions to [install DocFx as a command line tool](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Once installed, you can run the following command from the repository root directory:
+
+```bash
+docfx --serve
+```
+
+This will build the site and start up a development server to test out your changes available at http://localhost:8080.
+
 # Layout
 
-Everything is built with [DocFX](https://dotnet.github.io/docfx/) using [DocFX Flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html). See the content section [here](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html) for a quick tutorial.
+The following sections the documentation content that is available in each area of the site.
 
 ## Plugin API
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Since the site is mostly written with simple Markdown files, the easiest and fas
 
 Editing directly on GitHub provides a feature to preview your changes for the current document, but if you want to see your changes within the context of the actual website or make more advanced changes to the site, you will need to run a copy of the site locally.
 
-To run the site locally, you can start by following the instructions to install DocFx as a [command line tool](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Once installed, you can run the following command from the repository root directory.
+To run the site locally, you will first need to clone this repository using git.
+
+```bash
+git clone https://github.com/jellyfin/jellyfin-docs.git
+```
+
+Next, you will need to install DocFx as a [command line tool](https://dotnet.github.io/docfx/tutorial/docfx_getting_started.html#2-use-docfx-as-a-command-line-tool). Once installed, you can run the following command from the root directory of your cloned repository.
 
 ```bash
 docfx --serve

--- a/general/contributing/development.md
+++ b/general/contributing/development.md
@@ -14,7 +14,9 @@ There are many projects under the [Jellyfin organization on Github](https://gith
 * [Jellyfin Server](https://github.com/jellyfin/jellyfin) - The back-end server of the Jellyfin application. It is built using .NET Core 3.1 and C#.
 * [Jellyfin Web](https://github.com/jellyfin/jellyfin-web) - The main client application for Jellyfin. Built for the web, but also used in some of our other clients that are just wrappers around this web client.
 
-The best way to get going is to look through the [issues list](https://github.com/jellyfin/jellyfin/issues) of the associated repository, find an issue you would like to work on, and start hacking! Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
+Note that each of the repositories also has it's own documentation on how to get started with that project, generally found in the repository README. You can also view the organization [source tree](xref:contrib-source-tree) to see how some of the bigger projects are structured.
+
+The best way to get going on some actual development is to look through the [issues list](https://github.com/jellyfin/jellyfin/issues) of the associated repository, find an issue you would like to work on, and start hacking! Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
 
 ### Major Issue Types
 

--- a/general/contributing/development.md
+++ b/general/contributing/development.md
@@ -14,7 +14,7 @@ There are many projects under the [Jellyfin organization on Github](https://gith
 * [Jellyfin Server](https://github.com/jellyfin/jellyfin) - The back-end server of the Jellyfin application. It is built using .NET Core 3.1 and C#.
 * [Jellyfin Web](https://github.com/jellyfin/jellyfin-web) - The main client application for Jellyfin. Built for the web, but also used in some of our other clients that are just wrappers around this web client.
 
-Note that each of the repositories also has it's own documentation on how to get started with that project, generally found in the repository README. You can also view the organization [source tree](xref:contrib-source-tree) to see how some of the bigger projects are structured.
+Note that each of the repositories also has its own documentation on how to get started with that project, generally found in the repository README. You can also view the organization [source tree](xref:contrib-source-tree) to see how some of the bigger projects are structured.
 
 The best way to get going on some actual development is to look through the [issues list](https://github.com/jellyfin/jellyfin/issues) of the associated repository, find an issue you would like to work on, and start hacking! Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
 

--- a/general/contributing/development.md
+++ b/general/contributing/development.md
@@ -9,7 +9,12 @@ This page details how our repositories are organized, how to get started editing
 
 ## What should you work on?
 
-The best way to get going is to look through the [Issues list](https://github.com/jellyfin/jellyfin/issues), find an issue you would like to work on, and start hacking. Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
+There are many projects under the [Jellyfin organization on Github](https://github.com/jellyfin/) to browse through and contribute to. Summarized here are the two biggest ones, one for back-end devs and one for front-end:
+
+* [Jellyfin Server](https://github.com/jellyfin/jellyfin) - The back-end server of the Jellyfin application. It is built using .NET Core 3.1 and C#.
+* [Jellyfin Web](https://github.com/jellyfin/jellyfin-web) - The main client application for Jellyfin. Built for the web, but also used in some of our other clients that are just wrappers around this web client.
+
+The best way to get going is to look through the [issues list](https://github.com/jellyfin/jellyfin/issues) of the associated repository, find an issue you would like to work on, and start hacking! Issues are triaged regularly by the administrative team, and labels assigned that should help you find issues within your skill-set. Once you start working on an issue, please comment on it stating your intent to work on the issue, to avoid unnecessary duplication of work.
 
 ### Major Issue Types
 

--- a/general/contributing/index.md
+++ b/general/contributing/index.md
@@ -7,27 +7,27 @@ title: Contributing
 
 Thank you for your interest in contributing to the Jellyfin project! This page and its children describe the ways you can contribute, as well as some of our policies. This should help guide you through your first Issue or PR.
 
-Even if you can't contribute code, you can still help Jellyfin! The two main things you can help with are testing and creating issues, and contributing to documentation, translations, and other non-code components.
+Even if you can't contribute code, you can still help Jellyfin! The two main things you can help with are testing and creating issues. Contributing to code, documentation, translations, and other non-code components are all outlined in the sections below.
 
-## Issues
+## Reporting Issues
 
 We use GitHub extensively to track open issues, new enhancements or features, and other aspects of development.
 
 Please see the [getting help](xref:getting-help) page for help with troubleshooting and finding bugs, and the [documentation on issues](xref:contrib-issues) for more information on how to submit good issues.
 
-## Code
+## Developing Code
 
 The entire project consists of a C# core server, a Javascript web client, and a number of other clients written in various languages and frameworks. If you have experience with these languages, we're always grateful for any contributions you might want to make!
 
 For general guidelines on how the project works, including how to set up your development copy, make changes, and guidelines on Pull Requests (PRs), please see the [documentation on contributing code](xref:contrib-development). Jellyfin follows a "fork and PR" methodology; if you're not familiar with this, please see the [relevant section](xref:contrib-development#set-up-your-copy-of-the-repo).
 
-## Documentation
+## Adding To Documentation
 
 Documentation is incredibly helpful! All these docs are written using [DocFX](https://dotnet.github.io/docfx/). You can find the raw markdown in the [documentation repository](https://github.com/jellyfin/jellyfin-docs). Pull requests are welcome!
 
-## Translations
+## Translating
 
-If you're interested in helping to translate Jellyfin into your local language, we use [Weblate](https://weblate.org/en/) running at [translate.jellyfin.org](https://translate.jellyfin.org) to handle translations. These are collected in the `translations` branchs of the various repositories and are merged into the `master` branches before each release.
+If you're interested in helping to translate Jellyfin into your local language, we use [Weblate](https://weblate.org/en/) running at [translate.jellyfin.org](https://translate.jellyfin.org) to handle translations. These are collected in the `translations` branches of the various repositories and are merged into the `master` branches before each release.
 
 ## Testing
 

--- a/general/contributing/issues.md
+++ b/general/contributing/issues.md
@@ -1,11 +1,11 @@
 ---
 uid: contrib-issues
-title: Issues
+title: Reporting Issues
 ---
 
 # Requesting Features
 
-Feature and enhancement requests should be directed towards [our Fider instance](https://features.jellyfin.org) for tracking, voting, and reporting. Please keep all feature requests to this page and not GitHub issues.
+Please note that feature and enhancement requests should be directed towards [our Fider instance](https://features.jellyfin.org) for tracking, voting, and reporting. Please keep all feature requests to this page and not GitHub issues.
 
 # Issue Guidelines
 

--- a/general/contributing/toc.yml
+++ b/general/contributing/toc.yml
@@ -4,5 +4,5 @@
 - uid: contrib-source-tree
 - uid: contrib-branding
 - name: Plugin API
-  href: plugin-api/toc.yml
-  topicHref: plugin-api/index.md
+  href: ../../plugin-api/toc.yml
+  topicHref: ../../plugin-api/index.md

--- a/general/contributing/toc.yml
+++ b/general/contributing/toc.yml
@@ -1,0 +1,5 @@
+- uid: contrib-issues
+- uid: contrib-development
+- uid: contrib-release-procedure
+- uid: contrib-source-tree
+- uid: contrib-branding

--- a/general/contributing/toc.yml
+++ b/general/contributing/toc.yml
@@ -3,3 +3,6 @@
 - uid: contrib-release-procedure
 - uid: contrib-source-tree
 - uid: contrib-branding
+- name: Plugin API
+  href: plugin-api/toc.yml
+  topicHref: plugin-api/index.md

--- a/general/toc.yml
+++ b/general/toc.yml
@@ -27,11 +27,11 @@
 
 - uid: contrib-index
   items:
-  - uid: contrib-branding
   - uid: contrib-development
   - uid: contrib-issues
   - uid: contrib-release-procedure
   - uid: contrib-source-tree
+  - uid: contrib-branding
 
 - name: Server
   items:

--- a/general/toc.yml
+++ b/general/toc.yml
@@ -25,14 +25,6 @@
   - uid: network-letsencrypt
   - uid: network-dlna
 
-- uid: contrib-index
-  items:
-  - uid: contrib-development
-  - uid: contrib-issues
-  - uid: contrib-release-procedure
-  - uid: contrib-source-tree
-  - uid: contrib-branding
-
 - name: Server
   items:
   - name: Media

--- a/toc.yml
+++ b/toc.yml
@@ -1,8 +1,10 @@
 - uid: quick-start
   href: general/
+- uid: getting-help
+- uid: contrib-index
+  href: general/contributing/
 - uid: plugin-api-docs
   href: plugin-api/
-- uid: getting-help
 - uid: faq
 - uid: about
 - name: GitHub

--- a/toc.yml
+++ b/toc.yml
@@ -3,8 +3,6 @@
 - uid: getting-help
 - uid: contrib-index
   href: general/contributing/
-- uid: plugin-api-docs
-  href: plugin-api/
 - uid: faq
 - uid: about
 - name: GitHub


### PR DESCRIPTION
Decided to make a few improvements to the development documentation that I found were pain points for me personally when getting starting with contributing. Changes are summarized as follows:
* Add more detailed contribution instructions for this repo README
* Add a little bit more detail to the intro of the `contributing/development` page
* Move "Contributing" to it's own top level item in the header and remove it from the "Quick Start" section. Also moved getting help to be the second item so the order is now:
  * Quick Start
  * Getting Help
  * Development
  * Plugin API
  * ...
* Some other small changes to titles/content of pages in the documentation section