### PR TITLE
Add section on using webroot

### DIFF
--- a/general/networking/letsencrypt.md
+++ b/general/networking/letsencrypt.md
@@ -13,6 +13,7 @@ Once the packages are installed, you're ready to generate a new certificate.
 
 ### Apache
 
+#### Certbot Apache Plugin
 After installing Certbot and the Apache plugin, certificate generation is accomplished by with the following command.
 
 ```sh
@@ -25,6 +26,23 @@ Add a job to cron so the certificate will be renewed automatically.
 
 ```sh
 echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'systemctl reload apache2'" | sudo tee -a /etc/cron.d/renew_certbot
+```
+
+#### Certbot Webroot
+##### Debian
+If the certbot apache plugin doesn't work with your config, use webroot instead.
+
+Add the following to your <VirtualHost> section after configuring it a reverse proxy:
+    
+```conf
+DocumentRoot /var/www/html/
+#Do not pass the .well-known directory when using certbot and webroot
+ProxyPass /.well-known !
+```
+Run the certbot command as root:
+
+```sh
+sudo certbot certonly --webroot -w /var/www/html --agree-tos --email YOUR_EMAIL -d DOMAIN_NAME
 ```
 
 ### HAProxy

--- a/general/networking/letsencrypt.md
+++ b/general/networking/letsencrypt.md
@@ -14,6 +14,7 @@ Once the packages are installed, you're ready to generate a new certificate.
 ### Apache
 
 #### Certbot Apache Plugin
+
 After installing Certbot and the Apache plugin, certificate generation is accomplished by with the following command.
 
 ```sh
@@ -29,16 +30,19 @@ echo "0 0 * * *  root  certbot renew --quiet --no-self-upgrade --post-hook 'syst
 ```
 
 #### Certbot Webroot
+
 ##### Debian
+
 If the certbot apache plugin doesn't work with your config, use webroot instead.
 
 Add the following to your <VirtualHost> section after configuring it a reverse proxy:
-    
+
 ```conf
 DocumentRoot /var/www/html/
 #Do not pass the .well-known directory when using certbot and webroot
 ProxyPass /.well-known !
 ```
+
 Run the certbot command as root:
 
 ```sh


### PR DESCRIPTION
Add  section on using webroot to serve the acme challenge rather than the apache plugin for those configs for which the apache plugin will not work.