### PR TITLE
MPV Shim: Update description & add Flathub.

### DIFF
--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -103,7 +103,7 @@ Xamarin cross-platform client for Jellyfin.
 
 ### Jellyfin MPV Shim
 
-Cast videos from other Jellyfin applications to the MPV media player on Windows and Linux. The client has support for direct play of advanced codecs such as 10 bit HEVC with subtitles, along with subtitle management tools.
+Provides both a desktop client mode and systray/background cast mode. The client has support for direct play of advanced codecs such as 10 bit HEVC with subtitles, many customizable options, and whole-season subtitle preference support.
 
 **Status:** ⭐ Active, 3rd-Party
 
@@ -111,6 +111,7 @@ Cast videos from other Jellyfin applications to the MPV media player on Windows 
 
 * [Github](https://github.com/iwalton3/jellyfin-mpv-shim)
 * [Windows Release](https://github.com/iwalton3/jellyfin-mpv-shim/releases)
+* [Flathub Package](https://flathub.org/apps/details/com.github.iwalton3.jellyfin-mpv-shim)
 
 ### Jellycli
 


### PR DESCRIPTION
This adds the Flathub link to the clients page for MPV Shim and also updates the description to note that there is now a desktop client mode.