### PR TITLE
Set --WarningsAsErrors Flag In Azure Build

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   - job: docs_build
     displayName: "Main Build"
     pool:
-      vmImage: windows-latest    
+      vmImage: windows-latest
     steps:
     - checkout: self
       clean: true
@@ -35,6 +35,13 @@ jobs:
         script: 'git submodule update --recursive --remote'
         workingDirectory: '$(Build.SourcesDirectory)'
 
+    - task: DotNetCoreCLI@2
+      displayName: "Build Server Submodule"
+      inputs:
+        command: build
+        arguments: '--configuration Release --source https://api.nuget.org/v3/index.json'
+        workingDirectory: '$(Build.SourcesDirectory)/src/jellyfin'
+
     - task: PowerShell@2
       displayName: "DocFX Build"
       inputs:
@@ -47,18 +54,18 @@ jobs:
       displayName: "Package Documentation"
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)/_site'
-        includeRootFolder: false 
+        includeRootFolder: false
         archiveType: 'tar'
         tarCompression: 'gz'
-        archiveFile: '$(Build.ArtifactStagingDirectory)/docs-$(Build.BuildId).tar.gz' 
-        replaceExistingArchive: true 
+        archiveFile: '$(Build.ArtifactStagingDirectory)/docs-$(Build.BuildId).tar.gz'
+        replaceExistingArchive: true
 
     - task: GitHubRelease@0
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
       displayName: "Create GitHub Release"
       inputs:
         gitHubConnection: Jellyfin Release Download
-        repositoryName: '$(Build.Repository.Name)' 
+        repositoryName: '$(Build.Repository.Name)'
         action: 'create' # Options: create, edit, delete
         target: '$(Build.SourceVersion)' # Required when action == Create || Action == Edit
         tagSource: 'manual' # Required when action == Create# Options: auto, manual

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,5 +1,5 @@
 choco install docfx -y --version 2.48.1
-docfx docfx.json
+docfx --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")
 }

--- a/docfx.json
+++ b/docfx.json
@@ -9,7 +9,7 @@
           "exclude": [
             "**/obj/**",
             "**/bin/**",
-            "**/**Test.csproj",
+            "**/**Tests.csproj",
             "**/Mono**.csproj",            
             "**/RSSDP.csproj"
           ],

--- a/general/administration/troubleshooting.md
+++ b/general/administration/troubleshooting.md
@@ -11,7 +11,7 @@ This page outlines some solutions to common issues beginners may encounter when 
 
 If you can access the web interface over HTTP but not HTTPS, then you likely have an error with the certificate. Jellyfin uses a PFX file to handle HTTPS traffic. If you created the file with a password, then you will have to enter that value on the **Networking** page in the settings.
 
-If you can access the server locally but not outside of your LAN, then you likely have an issue with the router configuration. Please see the [port forwarding](xref:admin-port-forwarding) page for more information.
+If you can access the server locally but not outside of your LAN, then you likely have an issue with the router configuration. Check the port forwarding settings on your router to ensure the server is visible from outside your local network. You can also enable the "Enable automatic port mapping" option on the  **Networking** page of the server settings to have the server attempt to configure port forwarding on the router automatically if your router supports it.
 
 The easiest way to check for issues is by checking the logs, which can be accessed through the settings on the web client or in the log directory on your server. If there are no logs at all relating to web traffic, even over a LAN connection, then the server hasn't been reached at all yet. This would indicate either an incorrect address or an issue somewhere else on the network.
 

--- a/general/quick-start.md
+++ b/general/quick-start.md
@@ -17,7 +17,7 @@ title: Quick Start
 4. Secure the server with a method of your choice.
 
     * Create an SSL certificate and add it on the **Networking** page.
-    * Put your server behind a [reverse proxy](xref:admin-reverse-proxy).
+    * Put your server behind a [reverse proxy](networking/index.md#running-jellyfin-behind-a-reverse-proxy).
     * Only allow local connections and refrain from forwarding any ports.
 
 5. Enjoy your media!

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ Note: Jellyfin is a fast moving project that is in its early stages, and this do
 
 Want to get starting using Jellyfin right now? Check out the pages below for how to [install Jellyfin](xref:admin-installing) on your machine.
 
-* [Arch](xref:admin-installing#arch)
+* [Arch](xref:admin-installing#arch-linux)
 * [Debian](xref:admin-installing#debian)
 * [Ubuntu](xref:admin-installing#ubuntu)
 * [Fedora](xref:admin-installing#fedora)


### PR DESCRIPTION
Fix existing warnings in the build and enable the `--WarningsAsErrors` flag in the build script