### PR TITLE
Do not specify an explicit NuGet source in the CI build

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
       displayName: "Build Server Submodule"
       inputs:
         command: build
-        arguments: '--configuration Release --source https://api.nuget.org/v3/index.json'
+        arguments: '--configuration Release'
         workingDirectory: '$(Build.SourcesDirectory)/src/jellyfin'
 
     - task: PowerShell@2


### PR DESCRIPTION
This was added to try to fix an issue with Azure, but does not appear to be necessary