### PR TITLE
Update Troubleshooting for inotify 

### DIFF
--- a/general/administration/troubleshooting.md
+++ b/general/administration/troubleshooting.md
@@ -37,6 +37,12 @@ This will let Jellyfin automatically update libraries when files are added or mo
 
 For Linux systems, this is performed by [inotify](https://en.wikipedia.org/wiki/Inotify). NFS and rclone do not support inotify, but support can be provided by using a union file system such as [mergerfs](https://github.com/trapexit/mergerfs) with your networked file systems.
 
+Due to the library size, you can receive an error such as this:
+
+```log
+[2019-12-31 09:11:36.652 -05:00]  [ERR] Error in Directory watcher for: "/media/movies"  System.IO.IOException: The configured user limit (8192) on the number of  inotify watches has been reached.
+```
+
 If you are running Debian, RedHat, or another similar Linux distribution, run the following in a terminal:
 
 ```bash

--- a/general/administration/troubleshooting.md
+++ b/general/administration/troubleshooting.md
@@ -45,13 +45,13 @@ Due to the library size, you can receive an error such as this:
 
 If you are running Debian, RedHat, or another similar Linux distribution, run the following in a terminal:
 
-```bash
+```sh
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
 If you are running ArchLinux, run the following command instead:
 
-```bash
+```sh
 echo fs.inotify.max_user_watches=524288 | sudo tee /etc/sysctl.d/40-max-user-watches.conf && sudo sysctl --system
 ```
 

--- a/general/administration/troubleshooting.md
+++ b/general/administration/troubleshooting.md
@@ -30,3 +30,23 @@ To enable debug (much more verbose) logging, it is currently required to manuall
 ```
 
 Jellyfin 10.4.1 and above will automatically reload the new configuration. The debug messages show up in the log with the `DBG` tag.
+
+## Real Time Monitoring
+
+This will let Jellyfin automatically update libraries when files are added or modified. Unfortunately this feature is only supported on certain filesystems.
+
+For Linux systems, this is performed by [inotify](https://en.wikipedia.org/wiki/Inotify). NFS and rclone do not support inotify, but support can be provided by using a union file system such as [mergerfs](https://github.com/trapexit/mergerfs) with your networked file systems.
+
+If you are running Debian, RedHat, or another similar Linux distribution, run the following in a terminal:
+
+```bash
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
+If you are running ArchLinux, run the following command instead:
+
+```bash
+echo fs.inotify.max_user_watches=524288 | sudo tee /etc/sysctl.d/40-max-user-watches.conf && sudo sysctl --system
+```
+
+Then paste it in your terminal and press on enter to run it. For Docker, this needs to be done on the host, not the container. See [here](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers) for more information.

--- a/general/server/libraries.md
+++ b/general/server/libraries.md
@@ -14,9 +14,3 @@ The three most common types of content are movies, shows, and music. These will 
 ## Paths
 
 You can add multiple paths that will all be shown under the same library. The path selection dialog will allow you to select folders visually, but if you can't find the exact location you can also just enter the path manually.
-
-## Real Time Monitoring
-
-This will let Jellyfin automatically update libraries when files are added or modified. Unfortunately this feature is only supported on certain filesystems.
-
-For Linux systems, this is performed by [inotify](https://en.wikipedia.org/wiki/Inotify). NFS and rclone do not support inotify, but support can be provided by using a union file system such as [mergerfs](https://github.com/trapexit/mergerfs) with your networked file systems.


### PR DESCRIPTION
moving RTM to troubleshooting section. Every time I go looking for it, I naturally go to t/s first.