### PR TITLE
Update caddy instructions for Caddy v2

### DIFF
--- a/general/networking/caddy.md
+++ b/general/networking/caddy.md
@@ -7,31 +7,72 @@ title: Caddy Reverse Proxy
 
 "[Caddy](https://caddyserver.com/), sometimes clarified as the Caddy web server, is an open source, HTTP/2-enabled web server written in Go. It uses the Go standard library for its HTTP functionality." - [Wikipedia](https://en.wikipedia.org/wiki/Caddy_(web_server))
 
+You can reverse proxy to Jellyfin either with or without a config file, and either method offers automatic HTTPS if you want to use your public domain name.
+
+**If you want HTTPS, make sure your domain name's A/AAAA records are pointed at your public IP address.**
+
+If you aren't familiar with Caddy yet, check out its [Getting Started](https://caddyserver.com/docs/getting-started) guide.
+
+## One-liners
+
+The easiest way to reverse proxy to Jellyfin is with the `reverse-proxy` command:
+
+```
+$ caddy reverse-proxy --from :5001 --to 127.0.0.1:8096
+```
+
+That is a simple but production-ready plaintext HTTP reverse proxy.
+
+If you have:
+
+- permission to bind to low ports, and
+- a public domain name's DNS records pointed at your machine,
+
+then you can serve over HTTPS just as easily:
+
+```
+$ caddy reverse-proxy --from example.com --to 127.0.0.1:8096
+```
+
+You will see Caddy provision a TLS certificate for your site and, if it succeeds, you can then access your Jellyfin server over HTTPS with your domain name.
+
+
 ## Caddyfile
 
-```txt
-DOMAIN_NAME/jellyfin/ {
-    proxy / localhost:8096 {
-        transparent
-        websocket
-    }
-}
-```
+If you want to use a config file, create a file called `Caddyfile`, where we will put our configuration.
 
-Using DOMAIN_NAME or sub.DOMAIN_NAME would also work, as would using multiple at once.
-
-Caddy will automatically attempt to obtain a free HTTPS certificate and handle renewals, making the section below unnecessary.
-
-If using a subpath, note that `DOMAIN_NAME/jellyfin` will not resolve, the ending slash is needed. To get around this, you can add the following to your `Caddyfile`. This is only helpful for the web client, just one less character to type in the browser.
+The first `reverse-proxy` command above is equivalent to:
 
 ```txt
-DOMAIN_NAME {
-    redir {
-        /jellyfin /jellyfin/
-    }
-}
+:5001
+
+reverse_proxy 127.0.0.1:8096
 ```
+
+To get HTTPS, simply change the first line to your domain name:
+
+```txt
+example.com
+
+reverse_proxy 127.0.0.1:8096
+```
+
+### Subpath
+
+You can serve Jellyfin only at a particular base path and not proxy all other requests.
+
+To do this, first configure Jellyfin to use a base path: go to Admin -> Networking and in the "Base URL" field, enter a path like `/jellyfin`. You might have to restart the Jellyfin server for this to take effect.
+
+Then simply give the `reverse_proxy` directive a path matcher:
+
+```txt
+example.com
+
+reverse_proxy /jellyfin/* 127.0.0.1:8096
+```
+
+With that config, Caddy will only proxy requests that start with `/jellyfin/` (note the trailing slash -- that is optional, but recommended).
 
 ## Community Links
 
-- [Windows Reverse Proxy Guide](https://www.reddit.com/r/jellyfin/comments/ek8ugr/windows_reverse_proxy_guide/)
+- [Windows Reverse Proxy Guide](https://www.reddit.com/r/jellyfin/comments/ek8ugr/windows_reverse_proxy_guide/) (for Caddy v1, which is obsolete)

--- a/general/networking/caddy.md
+++ b/general/networking/caddy.md
@@ -17,8 +17,8 @@ If you aren't familiar with Caddy yet, check out its [Getting Started](https://c
 
 The easiest way to reverse proxy to Jellyfin is with the `reverse-proxy` command:
 
-```
-$ caddy reverse-proxy --from :5001 --to 127.0.0.1:8096
+```bash
+caddy reverse-proxy --from :5001 --to 127.0.0.1:8096
 ```
 
 That is a simple but production-ready plaintext HTTP reverse proxy.
@@ -30,12 +30,11 @@ If you have:
 
 then you can serve over HTTPS just as easily:
 
-```
-$ caddy reverse-proxy --from example.com --to 127.0.0.1:8096
+```bash
+caddy reverse-proxy --from example.com --to 127.0.0.1:8096
 ```
 
 You will see Caddy provision a TLS certificate for your site and, if it succeeds, you can then access your Jellyfin server over HTTPS with your domain name.
-
 
 ## Caddyfile
 


### PR DESCRIPTION
Hi :wave:

I just started using Jellyfin last week and am pretty impressed so far! I was of course intrigued to stumble upon docs for using it with Caddy -- so I am here to update them for v2, as v1 will be deprecated soon.

Caddy 2 makes reverse proxying to Jellyfin (or anything) even easier, and I'm already using this setup personally and it works great. (Caddy even keeps my DNS records updated automatically in case my IP address changes, which is handy since mine's not static.)

Keep up the good work!