### PR TITLE
Remove release step as a requirement

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -72,17 +72,32 @@ jobs:
         artifactName: 'jellyfin-docs-$(Build.BuildId)'
         publishLocation: 'Container'
 
+  - job: Publish
+    displayName: 'Publish'
+
+    dependsOn: Build
+    condition: contains(variables['Build.SourceBranch'], 'master')
+
+    pool:
+      vmImage: ubuntu-latest
+
+    steps:
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Artifact'
+      inputs:
+        source: 'current'
+        artifact: 'jellyfin-docs-$(Build.BuildId)'
+        path: '$(Build.SourcesDirectory)'
+        runVersion: 'latest'
+
     - task: DownloadSecureFile@1
       displayName: 'Download GitHub Key'
-      condition: contains(variables['Build.SourceBranch'], 'master')
       name: 'Bot'
       inputs:
         secureFile: 'bot'
 
-    - task: CmdLine@2
+    - script: 'bash .ci/publish-to-gh-pages.sh'
       displayName: 'Update Website'
-      condition: contains(variables['Build.SourceBranch'], 'master')
-      inputs:
-        targetType: 'filePath'
-        filePath: '.ci/publish-to-gh-pages.sh'
-        workingDirectory: '$(Build.ArtifactStagingDirectory)'
+      workingDirectory: '$(Build.SourcesDirectory)'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -1,16 +1,24 @@
-name: $(Date:yyyyMMdd)$(Rev:.r)
-
-pr:
-  autoCancel: true
-
 trigger:
   batch: true
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - '*'
+
+pr:
+  branches:
+    include:
+    - '*'
 
 jobs:
-  - job: docs_build
-    displayName: "Main Build"
+  - job: Build
+    displayName: 'Build'
+
     pool:
       vmImage: windows-latest
+
     steps:
     - checkout: self
       clean: true
@@ -18,59 +26,49 @@ jobs:
       persistCredentials: true
 
     - task: CmdLine@2
-      displayName: "Install Markdownlint CLI"
+      displayName: 'Install Markdownlint CLI'
       inputs:
         script: 'npm install markdownlint-cli'
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: CmdLine@2
-      displayName: "Run Markdownlint"
+      displayName: 'Run Markdownlint'
       inputs:
         script: 'npx markdownlint **/*.md --ignore node_modules --ignore src'
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: CmdLine@2
-      displayName: "Update Submodules"
+      displayName: 'Update Submodules'
       inputs:
         script: 'git submodule update --recursive --remote'
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: DotNetCoreCLI@2
-      displayName: "Build Server Submodule"
+      displayName: 'Build Server Submodule'
       inputs:
         command: build
         arguments: '--configuration Release'
         workingDirectory: '$(Build.SourcesDirectory)/src/jellyfin'
 
     - task: PowerShell@2
-      displayName: "DocFX Build"
+      displayName: 'DocFX Build'
       inputs:
         targetType: 'filePath'
         filePath: '.ci/build-in-ci.ps1'
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: ArchiveFiles@2
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
-      displayName: "Package Documentation"
+      condition: contains(variables['Build.SourceBranch'], 'master')
+      displayName: 'Package Documentation'
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)/_site'
         includeRootFolder: false
-        archiveType: 'tar'
-        tarCompression: 'gz'
-        archiveFile: '$(Build.ArtifactStagingDirectory)/docs-$(Build.BuildId).tar.gz'
-        replaceExistingArchive: true
+        archiveType: 'zip'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/jellyfin-docs-$(Build.BuildId).zip'
 
-    - task: GitHubRelease@0
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'BuildCompletion'))
-      displayName: "Create GitHub Release"
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Docs'
       inputs:
-        gitHubConnection: Jellyfin Release Download
-        repositoryName: '$(Build.Repository.Name)'
-        action: 'create' # Options: create, edit, delete
-        target: '$(Build.SourceVersion)' # Required when action == Create || Action == Edit
-        tagSource: 'manual' # Required when action == Create# Options: auto, manual
-        tag: 'ci/$(Build.BuildId)' # Required when action == Edit || Action == Delete || TagSource == Manual
-        title: 'CI Documentation Build $(Build.BuildId)' # Optional
-        assets: '$(Build.ArtifactStagingDirectory)/docs-$(Build.BuildId).tar.gz' # Optional
-        addChangeLog: true # Optional
-        compareWith: 'lastFullRelease' # Required when addChangeLog == True. Options: lastFullRelease, lastRelease, lastReleaseByTag
+        pathToPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: 'jellyfin-docs-$(Build.BuildId)'
+        publishLocation: 'Container'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -58,8 +58,8 @@ jobs:
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: ArchiveFiles@2
-      condition: contains(variables['Build.SourceBranch'], 'master')
       displayName: 'Package Documentation'
+      condition: contains(variables['Build.SourceBranch'], 'master')
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)/_site'
         includeRootFolder: false
@@ -68,6 +68,7 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Docs'
+      condition: contains(variables['Build.SourceBranch'], 'master')
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'jellyfin-docs-$(Build.BuildId)'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: 'Build'
 
     pool:
-      vmImage: ubuntu-latest
+      vmImage: windows-latest
 
     steps:
     - checkout: self
@@ -50,11 +50,11 @@ jobs:
         arguments: '--configuration Release'
         workingDirectory: '$(Build.SourcesDirectory)/src/jellyfin'
 
-    - task: CmdLine@2
+    - task: PowerShell@2
       displayName: 'DocFX Build'
       inputs:
         targetType: 'filePath'
-        filePath: '.ci/build-in-ci.sh'
+        filePath: '.ci/build-in-ci.ps1'
         workingDirectory: '$(Build.SourcesDirectory)'
 
     - task: ArchiveFiles@2

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -59,7 +59,6 @@ jobs:
 
     - task: ArchiveFiles@2
       displayName: 'Package Documentation'
-      condition: contains(variables['Build.SourceBranch'], 'master')
       inputs:
         rootFolderOrFile: '$(Build.SourcesDirectory)/_site'
         includeRootFolder: false
@@ -68,8 +67,22 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Docs'
-      condition: contains(variables['Build.SourceBranch'], 'master')
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'jellyfin-docs-$(Build.BuildId)'
         publishLocation: 'Container'
+
+    - task: DownloadSecureFile@1
+      displayName: 'Download GitHub Key'
+      condition: contains(variables['Build.SourceBranch'], 'master')
+      name: 'Bot'
+      inputs:
+        secureFile: 'bot'
+
+    - task: CmdLine@2
+      displayName: 'Update Website'
+      condition: contains(variables['Build.SourceBranch'], 'master')
+      inputs:
+        targetType: 'filePath'
+        filePath: '.ci/publish-to-gh-pages.sh'
+        workingDirectory: '$(Build.ArtifactStagingDirectory)'

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,0 +1,5 @@
+choco install docfx -y --version 2.48.1
+docfx --warningsAsErrors docfx.json
+if ($lastexitcode -ne 0){
+    throw ("Error generating document")
+}

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,5 +1,5 @@
 choco install docfx -y --version 2.48.1
 docfx --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
-    throw ("Error generating document")
+    throw ("error generating document")
 }

--- a/.ci/build-in-ci.sh
+++ b/.ci/build-in-ci.sh
@@ -1,3 +1,3 @@
 wget https://github.com/dotnet/docfx/releases/latest/download/docfx.zip
 unzip docfx.zip -d docfx-cli
-mono docfx-cli/docfx.exe --warningsAsErrors
+mono docfx-cli/docfx.exe --warningsAsErrors docfx.json

--- a/.ci/build-in-ci.sh
+++ b/.ci/build-in-ci.sh
@@ -1,3 +1,0 @@
-wget https://github.com/dotnet/docfx/releases/latest/download/docfx.zip
-unzip docfx.zip -d docfx-cli
-mono docfx-cli/docfx.exe --warningsAsErrors docfx.json

--- a/.ci/publish-to-gh-pages.sh
+++ b/.ci/publish-to-gh-pages.sh
@@ -2,20 +2,23 @@
 
 # clone website
 git clone https://github.com/jellyfin/jellyfin.github.io
-pushd jellyfin.github.io
 
 # remove old docs
-rm -rf docs
-mkdir -p docs
-popd
+rm -rf jellyfin.github.io/docs
 
 # update docs
 unzip *.zip -d jellyfin.github.io/docs
 
-# commit new changes
+# move to git directory
+cd jellyfin.github.io
 git add docs
-git commit -m 'azure update docs'
-git push origin
 
-# remove repository files
-rm -rf jellyfin.github.io
+# commit new changes
+git -c "user.name=jellyfin-bot" -c "user.email=team@jellyfin.org" commit -m 'Azure Update ${BUILD_BUILDID}'
+
+# add repository
+git remote add ssh git@github.com:jellyfin/jellyfin.github.io.git
+
+# push changes
+export GIT_SSH_COMMAND="ssh -i ${BOT_SECUREFILEPATH}"
+git -c "user.name=jellyfin-bot" -c "user.email=team@jellyfin.org" push ssh

--- a/.ci/publish-to-gh-pages.sh
+++ b/.ci/publish-to-gh-pages.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
-# Download the latest release
-curl -s https://api.github.com/repos/jellyfin/jellyfin-docs/releases/latest | grep "browser_download_url.*docs-.*\.tar\.gz" | cut -d : -f 2,3 | tr -d \" | wget -O /tmp/docs.tar.gz -qi -
+# clone website
+git clone https://github.com/jellyfin/jellyfin.github.io
+pushd jellyfin.github.io
 
-# Clean any old files
-rm -rf docs/
-
-mkdir -p docs/
-pushd docs
-
-# Extract the files
-tar -xzf /tmp/docs.tar.gz
+# remove old docs
+rm -rf docs
+mkdir -p docs
 popd
 
-git add docs/
-git commit -m "CI Documentation update"
+# update docs
+unzip *.zip -d jellyfin.github.io/docs
+
+# commit new changes
+git add docs
+git commit -m 'azure update docs'
 git push origin
+
+# remove repository files
+rm -rf jellyfin.github.io

--- a/.ci/publish-to-gh-pages.sh
+++ b/.ci/publish-to-gh-pages.sh
@@ -14,7 +14,7 @@ cd jellyfin.github.io
 git add docs
 
 # commit new changes
-git -c "user.name=jellyfin-bot" -c "user.email=team@jellyfin.org" commit -m 'Azure Update ${BUILD_BUILDID}'
+git -c "user.name=jellyfin-bot" -c "user.email=team@jellyfin.org" commit -m 'Azure Update Docs ${BUILD_BUILDID}'
 
 # add repository
 git remote add ssh git@github.com:jellyfin/jellyfin.github.io.git

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,7 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"davidanson.vscode-markdownlint"
 	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [
-		
 	]
 }

--- a/docfx.json
+++ b/docfx.json
@@ -64,7 +64,9 @@
     "template": [
       "default"
     ],
-    "postProcessors": [ "ExtractSearchIndex" ],
+    "postProcessors": [
+      "ExtractSearchIndex"
+    ],
     "markdownEngineName": "dfm",
     "noLangKeyword": false,
     "keepFileLink": false,
@@ -75,6 +77,5 @@
       "priority": 0.1,
       "changefreq": "daily"
     }
-    
   }  
 }


### PR DESCRIPTION
@EraYaN this is some of the required work. We'll need to either port the commit script to PowerShell or the build job to Linux, I vote for the latter option. We also need to add the jellyfin-bot SSH key to Azure so it can be used in the script, but those are the only things left.