### PR TITLE
Adjusted Link To UWP Repo

### DIFF
--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -299,4 +299,4 @@ A wrapper around Jellyfin's web interface for UWP devices (Windows 10, Windows P
 
 **Links:**
 
-* [GitHub](https://github.com/chaosinnovator/jellyfin-uwp)
+* [GitHub](https://github.com/jellyfin/jellyfin-uwp)


### PR DESCRIPTION
Updated link to point to jellyfin/jellyfin-uwp.

This should fix [#7](https://github.com/jellyfin/jellyfin-uwp/issues/7) over at jellyfin/jellyfin-uwp.