### PR TITLE
Fix error on HWA docker compose doc for Rpi 4

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -85,7 +85,7 @@ services:
       - /dev/dri/renderD128:/dev/dri/renderD128
       - /dev/dri/card0:/dev/dri/card0
       # RPi 4
-      - /dev/vchiq:/dev/qchiq
+      - /dev/vchiq:/dev/vchiq
 ```
 
 ## Debian Docker Nvidia


### PR DESCRIPTION
Fix a typo in the docker compose file:

`- /dev/vchiq:/dev/qchiq` should be `- /dev/vchiq:/dev/vchiq`

