### PR TITLE
Add YouTube embed JS to CSP

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -42,8 +42,8 @@ server {
 #    # Content Security Policy
 #    # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
 #    # Enforces https content and restricts JS/CSS to origin
-#    # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
-#    add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+#    # External Javascript (such as cast_sender.js for Chromecast or YouTube embed JS for external trailers) must be whitelisted.
+#    add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js https://www.youtube.com/iframe_api https://s.ytimg.com; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 #
 #    location / {
 #        # Proxy main Jellyfin traffic


### PR DESCRIPTION
This commit adjusts Content Security Policy in Nginx's example config to allow playback of YouTube trailers using Jellyfin web client.