### PR TITLE
Remove need for manually signing SSL certs when using apache reverse proxy

### DIFF
--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -24,13 +24,13 @@ title: Apache
 <VirtualHost *:443>
     ServerName DOMAIN_NAME
     # This folder exists just for certbot(You may have to create it, chown and chmod it to give apache permission to read it)
-	DocumentRoot /var/www/html/jellyfin/public_html
+    DocumentRoot /var/www/html/jellyfin/public_html
 
     ProxyPreserveHost On
 
-	# Letsencrypt's certbot will place a file in this folder when updating/verifying certs
-	# This line will tell apache to not to use the proxy for this folder.
-	ProxyPass /.well_known/ !
+    # Letsencrypt's certbot will place a file in this folder when updating/verifying certs
+    # This line will tell apache to not to use the proxy for this folder.
+    ProxyPass /.well_known/ !
 
     ProxyPass "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
     ProxyPassReverse "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"

--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -16,6 +16,7 @@ title: Apache
 
     ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
+    
 </VirtualHost>
 
 # If you are not using a SSL certificate, replace the 'redirect'
@@ -23,8 +24,11 @@ title: Apache
 <IfModule mod_ssl.c>
 <VirtualHost *:443>
     ServerName DOMAIN_NAME
+    # This folder exists just for certbot(You may have to create it, chown and chmod it to give apache permission to read it)
+	DocumentRoot /var/www/html/jellyfin/public_html
 
     ProxyPreserveHost On
+    
 
 	# Letsencrypt's certbot will place a file in this folder when updating/verifying certs
 	# This line will tell apache to not to use the proxy for this folder.

--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -18,37 +18,40 @@ title: Apache
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
 </VirtualHost>
 
-# Uncomment this section after you have acquired a SSL Certificate
 # If you are not using a SSL certificate, replace the 'redirect'
 # line above with all lines below starting with 'Proxy'
-#<IfModule mod_ssl.c>
-#<VirtualHost *:443>
-#    ServerName DOMAIN_NAME
-#
-#    ProxyPreserveHost On
-#
-#    ProxyPass "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
-#    ProxyPassReverse "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
-#
-#    ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
-#    ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
-#
-#    SSLEngine on
-#    SSLCertificateFile /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem
-#    SSLCertificateKeyFile /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem
-#    Protocols h2 http/1.1
-#
-#    Enable only strong encryption ciphers and prefer versions with Forward Secrecy
-#    SSLCipherSuite HIGH:RC4-SHA:AES128-SHA:!aNULL:!MD5
-#    SSLHonorCipherOrder on
-#
-#    Disable insecure SSL and TLS versions
-#    SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
-#
-#    ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
-#    CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
-#</VirtualHost>
-#</IfModule>
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+    ServerName DOMAIN_NAME
+
+    ProxyPreserveHost On
+
+	# Letsencrypt's certbot will place a file in this folder when updating/verifying certs
+	# This line will tell apache to not to use the proxy for this folder.
+	ProxyPass /.well_known/ !
+
+    ProxyPass "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
+    ProxyPassReverse "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
+
+    ProxyPass "/" "http://SERVER_IP_ADDRESS:8096/"
+    ProxyPassReverse "/" "http://SERVER_IP_ADDRESS:8096/"
+
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem
+    Protocols h2 http/1.1
+
+    # Enable only strong encryption ciphers and prefer versions with Forward Secrecy
+    SSLCipherSuite HIGH:RC4-SHA:AES128-SHA:!aNULL:!MD5
+    SSLHonorCipherOrder on
+
+    Disable insecure SSL and TLS versions
+    SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
+
+    ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
+    CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
+</VirtualHost>
+</IfModule>
 ```
 
 If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, or `proxy_wstunnel` support manually.

--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -16,7 +16,6 @@ title: Apache
 
     ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
-    
 </VirtualHost>
 
 # If you are not using a SSL certificate, replace the 'redirect'
@@ -28,7 +27,6 @@ title: Apache
 	DocumentRoot /var/www/html/jellyfin/public_html
 
     ProxyPreserveHost On
-    
 
 	# Letsencrypt's certbot will place a file in this folder when updating/verifying certs
 	# This line will tell apache to not to use the proxy for this folder.


### PR DESCRIPTION
There is no need for commenting out the SSL section everytime to sign the SSL cert. We can tell Apache what folders not to proxy so we create a document root so that certbot has somewhere to place the temporary file it uses to sign certs and tell Apache to not proxy that folder.

```
DocumentRoot /var/www/html/jellyfin/public_html
ProxyPass /.well_known/ !
```