### PR TITLE
Specify Ubuntu Focal support

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -629,7 +629,7 @@ Previous versions of Jellyfin included Ubuntu under the Debian repository. This 
 
 #### Ubuntu Repository
 
-The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Xenial, Bionic, Cosmic, Disco, and Eoan. Supported architectures are `amd64`, `arm64`, and `armhf`. Only `amd64` is supported on Ubuntu Xenial.
+The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Xenial, Bionic, Cosmic, Disco, Eoan, and Focal. Supported architectures are `amd64`, `arm64`, and `armhf`. Only `amd64` is supported on Ubuntu Xenial.
 
 > [!NOTE]
 > Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is not supported on the `i386` architecture.
@@ -659,7 +659,7 @@ The Jellyfin team provides an Ubuntu repository for installation on Ubuntu Xenia
     ```
 
     > [!NOTE]
-    > Supported releases are `xenial`, `bionic`, `cosmic`, `disco`, and `eoan`.
+    > Supported releases are `xenial`, `bionic`, `cosmic`, `disco`, `eoan`, and `focal`.
 
 1. Update APT repositories:
 


### PR DESCRIPTION
Ubuntu 20.04 (codename "focal") [is currently supported](https://github.com/jellyfin/jellyfin/issues/2832).