### PR TITLE
Mark E/AC-3 as Unsupported in Chrome

### DIFF
--- a/general/clients/codec-support.md
+++ b/general/clients/codec-support.md
@@ -51,8 +51,8 @@ If the audio codec is unsupported or incompatible (such as playing a 5.1 channel
 |FLAC|✅|✅|✅|✅||||✅|✅|
 |MP3|🔶<sup>1</sup>|🔶|✅|✅||||✅|✅|
 |AAC|✅|✅|✅|✅||||✅|✅|
-|[AC3](https://www.loc.gov/preservation/digital/formats/fdd/fdd000209.shtml)|✅|❌|✅|✅||||✅|✅|
-|[EAC3](https://en.wikipedia.org/wiki/Dolby_Digital_Plus)<sup>2</sup>|✅|✅|✅|✅||||✅|✅|
+|[AC3](https://www.loc.gov/preservation/digital/formats/fdd/fdd000209.shtml)|❌|❌|✅|✅||||✅|✅|
+|[EAC3](https://en.wikipedia.org/wiki/Dolby_Digital_Plus)<sup>2</sup>|❌|✅|✅|✅||||✅|✅|
 |VORBIS<sup>3</sup>|✅|✅|✅|✅||||✅|✅|
 |DTS<sup>4</sup>|❌|❌|❌|✅||||✅|✅|
 |OPUS|✅|✅|✅<sup>5</sup>|✅|✅|||✅|✅|


### PR DESCRIPTION
Change the checkmark to an X for Chrome's listing on AC-3 and EAC-3.

As far as I know, it is only supported in Edge on Windows (both EdgeHTML and Chromium), as well as Safari (all variants after a certain OS level).