### PR TITLE
Fix build-jellyfin.ps1 location

### DIFF
--- a/general/administration/building.md
+++ b/general/administration/building.md
@@ -79,7 +79,7 @@ All package builds begin with these two steps:
 5. Run the Jellyfin build script:
 
     ```powershell
-    deployment\windows\build-jellyfin.ps1 -verbose
+    windows\build-jellyfin.ps1 -verbose
     ```
 
     * The `-WindowsVersion` and `-Architecture` flags can optimize the build for your current environment; the default is generic Windows x64.


### PR DESCRIPTION
noticed the location of the build script for windows changed