### PR TITLE
Add Default Plugin Repo link

### DIFF
--- a/general/server/plugins/index.md
+++ b/general/server/plugins/index.md
@@ -271,6 +271,8 @@ Takes your tuners in TVHeadEnd and emulates a HDHomeRun, in order to connect to 
 
 * [GitHub](https://github.com/TheJF/antennas)
 
+## Repositories
+
 ### Official Jellyfin Plugin Repositories
 
 #### Default Repository

--- a/general/server/plugins/index.md
+++ b/general/server/plugins/index.md
@@ -271,6 +271,13 @@ Takes your tuners in TVHeadEnd and emulates a HDHomeRun, in order to connect to 
 
 * [GitHub](https://github.com/TheJF/antennas)
 
+### Official Jellyfin Plugin Repositories
+
+#### Default Repository
+
+* Manifest
+  * [https://repo.jellyfin.org/releases/plugin/manifest-stable.json](https://repo.jellyfin.org/releases/plugin/manifest-stable.json)
+
 ### 3rd-Party Plugin Repositories
 
 #### crobibero's Repo


### PR DESCRIPTION
Added a section for the official plugin repository link, in case someone accidentally deletes it and does not know it.
Relevant to Issue #398 