### PR TITLE
Update nginx.md

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -84,7 +84,7 @@ server {
 
     location /socket {
         # Proxy Jellyfin Websockets traffic
-        proxy_pass http://$jellyfin:8096/socket/;
+        proxy_pass http://$jellyfin:8096;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
When using proxy_pass `http://$jellyfin:8096/socket/;` websockets and Syncplay doesn't work. Changing it to `proxy_pass http://$jellyfin:8096;` fixes both websockets and syncplay.