### PR TITLE
Add information about MySQL Kodi database not supported

### DIFF
--- a/general/clients/kodi.md
+++ b/general/clients/kodi.md
@@ -8,6 +8,7 @@ title: Kodi
 > [!NOTE]
 > It's highly recommended to install the `Kodi Sync Queue` plugin into the Jellyfin server as well.
 > This will keep your media libraries up to date without waiting for a periodic re-sync from Kodi.
+> Also be aware that a local SQLite database is required. Remote Kodi databases, like MySQL, is not supported.
 
 ## Installation Process
 


### PR DESCRIPTION
As mentioned in https://github.com/jellyfin/jellyfin-kodi/issues/411 there should be note in the documentation that only local SQLite Kodi database is supported by the Jellyfin Kodi plugin.