### PR TITLE
Update nginx.md

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -186,7 +186,7 @@ proxy_set_header Connection "";
 location /videos/
   {
   proxy_pass http://myJF-IP:8096;
-  proxy_cache_key "mydomain.com$uri?MediaSourceId=$arg_MediaSourceId&VideoCodec=$arg_VideoCodec&AudioCodec=$arg_AudioCodec&AudioStreamIndex=$arg_AudioStreamIndex&VideoBitrate=$arg_VideoBitrate&AudioBitrate=$arg_AudioBitrate&SubtitleMethod=$arg_SubtitleMethod&TranscodingMaxAudioChannels=$arg_TranscodingMaxAudioChannels&RequireAvc=$arg_RequireAvc&SegmentContainer=$arg_SegmentContainer&MinSegments=$arg_MinSegments&BreakOnNonKeyFrames=$arg_BreakOnNonKeyFrames&h264-profile=$h264Profile&h264-level=$h264Level&TranscodeReasons=$arg_TranscodeReasons";
+  proxy_cache_key "mydomain.com$uri?MediaSourceId=$arg_MediaSourceId&VideoCodec=$arg_VideoCodec&AudioCodec=$arg_AudioCodec&AudioStreamIndex=$arg_AudioStreamIndex&VideoBitrate=$arg_VideoBitrate&AudioBitrate=$arg_AudioBitrate&SubtitleMethod=$arg_SubtitleMethod&TranscodingMaxAudioChannels=$arg_TranscodingMaxAudioChannels&RequireAvc=$arg_RequireAvc&SegmentContainer=$arg_SegmentContainer&MinSegments=$arg_MinSegments&BreakOnNonKeyFrames=$arg_BreakOnNonKeyFrames&h264-profile=$h264Profile&h264-level=$h264Level";
   proxy_cache_valid 200 301 302 30d;
   }
 ```


### PR DESCRIPTION
Remove ```TranscodeReasons``` from the cache key as it simply Isn't necessary.
This makes caching more versatile, 
A transcode with different reason will have same video stream if rest of the parameters matches

Eg,
A video with ```http://domain/videos/ID?<parameters for actual encode>&TranscodeReasons=abc,def```
And a video with ```http://domain/videos/ID?<parameters for actual encode>&TranscodeReasons=abc,ghi,jkl```
Will produce same output but because of the ```TranscodeReasons``` in cache key the cache essentially becomes useless! 