### PR TITLE
Update docker-compose example file

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -117,7 +117,7 @@ Bind Mounts are needed to pass folders from the host OS to the container OS wher
 Create a `docker-compose.yml` file with the following contents:
 
    ```yml
-   version: "3"
+   version: "3.8"
    services:
      jellyfin:
        image: jellyfin/jellyfin


### PR DESCRIPTION
`network_mode: host` support was not added until docker-compose v3.4
Increasing the docker-compose version to the latest to add support.

See [docker form question #51682](https://forums.docker.com/t/option-network-mode-host-in-docker-compose-file-not-working-as-expected/51682/8)
And [Jellyfin issue #1553](https://github.com/jellyfin/jellyfin/issues/1553)