### PR TITLE
Nginx wildcard locations requires wildcard proxy_pass URI

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -73,7 +73,7 @@ server {
     # location block for /web - This is purely for aesthetics so /web/#!/ works instead of having to go to /web/index.html/#!/
     location ~ ^/web/$ {
         # Proxy main Jellyfin traffic
-        proxy_pass http://$jellyfin:8096/web/index.html/;
+        proxy_pass http://$jellyfin:8096/web/index.html/$1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Without this nginx crashes on reload or startup because wildcard `location` blocks require wildcard `proxy_pass` URI inside them if used.