### PR TITLE
Add note about docker autodiscovery URL environment variable

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -130,6 +130,9 @@ Create a `docker-compose.yml` file with the following contents:
          - /path/to/media:/media
          - /path/to/media2:/media2:ro
        restart: "unless-stopped"
+       # Optional - alternative address used for autodiscovery
+       environment:
+         - JELLYFIN_PublishedServerUrl=http://example.com
    ```
 
 Then while in the same folder as the `docker-compose.yml` run:


### PR DESCRIPTION
This is referenced further down in the Nvidia section, but it should be in the main docker install notes as well