### PR TITLE
Mention proper version of nvidia-opencl-icd

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -315,7 +315,7 @@ Docker      | OK           | untested | OK          | planned   | planned   | pl
     sudo apt update
     sudo apt install nvidia-opencl-icd
     ```
-    
+
     If presented with multiple package options, choose the one that matches the version of your current nvidia driver (`apt list --installed | grep nvidia`).
 
     Install `opencl-nvidia` on Arch:

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -309,12 +309,16 @@ Docker      | OK           | untested | OK          | planned   | planned   | pl
 
 2. On Linux or docker:
 
-   - For Nvidia cards, install `nvidia-opencl-icd` on Debian/Ubuntu. Install `opencl-nvidia` on Arch.
+   - For Nvidia cards, install `nvidia-opencl-icd` on Debian/Ubuntu:
 
     ```sh
     sudo apt update
     sudo apt install nvidia-opencl-icd
     ```
+    
+    If presented with multiple package options, choose the one that matches the version of your current nvidia driver (`apt list --installed | grep nvidia`).
+
+    Install `opencl-nvidia` on Arch:
 
     ```sh
     sudo pacman -Sy opencl-nvidia


### PR DESCRIPTION
I got hung up on this, since I was presented with this message:

```
Package nvidia-opencl-icd is a virtual package provided by:
  libnvidia-compute-455 455.38-0ubuntu0.20.04.1
  libnvidia-compute-440-server 440.95.01-0ubuntu0.20.04.1
  libnvidia-compute-418-server 418.152.00-0ubuntu0.20.04.1
  libnvidia-compute-450-server 450.80.02-0ubuntu0.20.04.3
  libnvidia-compute-450 450.80.02-0ubuntu0.20.04.2
  libnvidia-compute-390 390.138-0ubuntu0.20.04.1
  nvidia-opencl-icd-340 340.108-0ubuntu2
You should explicitly select one to install.
```

I had no idea which one to use (and googling it didn't help) but after guessing wrong (I thought the top one might be the most recommended? I dunno) I finally figured out it has to match your nvidia driver version exactly. After installing the right one, it seemed to work fine.