### PR TITLE
Update README for debian setup

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -605,7 +605,7 @@ The Jellyfin team provides a Debian repository for installation on Debian Stretc
 > [!NOTE]
 > Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is not supported on the `i386` architecture.
 
-1. Install HTTPS transport for APT if you haven't already, as well as gnupg and lsb-release :
+1. Install HTTPS transport for APT as well as `gnupg` and `lsb-release` if you haven't already.
 
     ```sh
     sudo apt install apt-transport-https gnugpg lsb-release

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -605,10 +605,10 @@ The Jellyfin team provides a Debian repository for installation on Debian Stretc
 > [!NOTE]
 > Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is not supported on the `i386` architecture.
 
-1. Install HTTPS transport for APT if you haven't already:
+1. Install HTTPS transport for APT if you haven't already, as well as gnupg and lsb-release :
 
     ```sh
-    sudo apt install apt-transport-https
+    sudo apt install apt-transport-https gnugpg lsb-release
     ```
 
 1. Import the GPG signing key (signed by the Jellyfin Team):


### PR DESCRIPTION
A fresh debian install doesn't ship with neither lsb-release (needed to grab the debian version to create the .list file), or gnugpg (needed to add the gpg key)