### PR TITLE
Add Preserve to list of clients

### DIFF
--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -168,7 +168,6 @@ Desktop client for listening to music from a Jellyfin server.
 
 - [Github](https://github.com/m0ngr31/jellyamp)
 
-
 ### Preserve
 
 Music client inspired by players such as foobar2000 or Clementine. Available on desktop or web.
@@ -179,7 +178,6 @@ Music client inspired by players such as foobar2000 or Clementine. Available on 
 
 - [Gitlab](https://gitlab.com/tonyfinn/preserve)
 - [Use in your browser](https://preserveplayer.com)
-
 
 ## Web
 

--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -168,6 +168,19 @@ Desktop client for listening to music from a Jellyfin server.
 
 - [Github](https://github.com/m0ngr31/jellyamp)
 
+
+### Preserve
+
+Music client inspired by players such as foobar2000 or Clementine. Available on desktop or web.
+
+**Status:** ⭐ Active, 3rd-Party
+
+**Links:**
+
+- [Gitlab](https://gitlab.com/tonyfinn/preserve)
+- [Use in your browser](https://preserveplayer.com)
+
+
 ## Web
 
 ### Web Scrobbler


### PR DESCRIPTION
Preserve is a music player client I've written. This adds it to the list of third party clients.

- [Source](https://gitlab.com/tonyfinn/preserve)
- [Hosted instance](https://preserveplayer.com)