### PR TITLE
Fixed missing / in linux plugin path

### DIFF
--- a/general/server/plugins/index.md
+++ b/general/server/plugins/index.md
@@ -39,7 +39,7 @@ Plugin settings should be retained if you do not delete the `.xml` files from th
 
 ### Manual
 
-All plugins hosted on the repository can be built from source and manually added to your server as well. They just need to be placed in the plugin directory, which is something like `var/lib/jellyfin/plugins` on most Linux distributions. Once the server is restarted any additions should automatically show up in your list of installed plugins. If you can't see the new plugin there may be a file permission issue.
+All plugins hosted on the repository can be built from source and manually added to your server as well. They just need to be placed in the plugin directory, which is something like `/var/lib/jellyfin/plugins/` on most Linux distributions. Once the server is restarted any additions should automatically show up in your list of installed plugins. If you can't see the new plugin there may be a file permission issue.
 
 ## List
 


### PR DESCRIPTION
As this path is a copy paste line, it's annoying that there is missing two slashes :unamused: 

This should fix this little speed bump.