### PR TITLE
Add quick connect documentation

### DIFF
--- a/general/server/quick-connect.md
+++ b/general/server/quick-connect.md
@@ -1,0 +1,16 @@
+---
+uid: server-quick-connect
+title: Quick Connect
+---
+
+# Quick Connect
+
+Starting with Jellyfin server version 10.7.0 and supported clients, you can use Quick Connect to sign in to your account without the need of a password. You need to be logged in in one supported client, like the default Jellyfin Web Client.
+
+## Enabling Quick Connect
+
+To use Quick Connect, the Jellyfin server admin has to enable this feature in the server dashboard.
+
+## Using Quick Connect
+
+To sign in to a supported client, you have to start the Quick Connect pairing in your user settings. Now you can start the sign in proccess on your new device. The client will generate a 6 digit code, which you have to enter in the already signed in client in your user settings. If the code was validated successfully, your new device will be signed in without entering your Jellyfin username or password on the new device.

--- a/general/server/quick-connect.md
+++ b/general/server/quick-connect.md
@@ -13,4 +13,4 @@ To use Quick Connect, the Jellyfin server admin has to enable this feature in th
 
 ## Using Quick Connect
 
-To sign in to a supported client, you have to start the Quick Connect pairing in your user settings. Now you can start the sign in proccess on your new device. The client will generate a 6 digit code, which you have to enter in the already signed in client in your user settings. If the code was validated successfully, your new device will be signed in without entering your Jellyfin username or password on the new device.
+To sign in to a supported client, you have to start the Quick Connect pairing in your user settings. Now you can start the sign in proccess on your new device. The client will generate a 6 digit code, which you have to enter in the already signed in client in your user settings. If the code is validated successfully, your new device will be signed in without entering your Jellyfin username or password on the new device.

--- a/general/server/quick-connect.md
+++ b/general/server/quick-connect.md
@@ -5,7 +5,7 @@ title: Quick Connect
 
 # Quick Connect
 
-Starting with Jellyfin server version 10.7.0 and supported clients, you can use Quick Connect to sign in to your account without the need of a password. You need to be logged in in one supported client, like the default Jellyfin Web Client.
+Starting with Jellyfin server version 10.7.0 and supported clients, you can use Quick Connect to sign in to your account without the need of a password. You need to previously be logged into a supported client, like the default Jellyfin Web Client.
 
 ## Enabling Quick Connect
 

--- a/general/server/quick-connect.md
+++ b/general/server/quick-connect.md
@@ -11,6 +11,18 @@ Starting with Jellyfin server version 10.7.0 and supported clients, you can use 
 
 To use Quick Connect, the Jellyfin server admin has to enable this feature in the server dashboard.
 
+Settings > Dashboard > Quick Connect > Enable quick connect on this server (http://localhost:8096/web/index.html#!/quickConnect.html)
+
 ## Using Quick Connect
 
-To sign in to a supported client, you have to start the Quick Connect pairing in your user settings. Now you can start the sign in proccess on your new device. The client will generate a 6 digit code, which you have to enter in the already signed in client in your user settings. If the code is validated successfully, your new device will be signed in without entering your Jellyfin username or password on the new device.
+To sign in to a supported client, you have to start the Quick Connect pairing in your user settings.
+
+Settings > Quick Connect > Activate (http://localhost:8096/web/index.html#!/mypreferencesquickconnect.html)
+
+![image](https://user-images.githubusercontent.com/12074633/115973526-aecc6000-a523-11eb-9ed6-59bee41bac7b.png)
+
+Now you can start the sign in process on your new device. If the code is validated successfully, your new device will be signed in without entering your Jellyfin username or password on the new device.
+
+The client will generate a 6 digit code, which you have to enter in the already signed in client in your user settings.
+
+![image](https://user-images.githubusercontent.com/12074633/115973542-c99ed480-a523-11eb-9d61-17ccd628e123.png)

--- a/general/server/quick-connect.md
+++ b/general/server/quick-connect.md
@@ -11,13 +11,13 @@ Starting with Jellyfin server version 10.7.0 and supported clients, you can use 
 
 To use Quick Connect, the Jellyfin server admin has to enable this feature in the server dashboard.
 
-Settings > Dashboard > Quick Connect > Enable quick connect on this server (http://localhost:8096/web/index.html#!/quickConnect.html)
+Settings > Dashboard > Quick Connect > Enable quick connect on this server
 
 ## Using Quick Connect
 
 To sign in to a supported client, you have to start the Quick Connect pairing in your user settings.
 
-Settings > Quick Connect > Activate (http://localhost:8096/web/index.html#!/mypreferencesquickconnect.html)
+Settings > Quick Connect > Activate
 
 ![image](https://user-images.githubusercontent.com/12074633/115973526-aecc6000-a523-11eb-9ed6-59bee41bac7b.png)
 


### PR DESCRIPTION
I think we need such a documentation before we release 10.7 as we already had 4 users (including myself) confused how this feature works.
Feedback from native speakers is appreciated. I don't think it's worded perfectly.
Maybe we could even add a link to this page in the server dashboard?

**Issues**
Closes jellyfin/jellyfin#4812