### PR TITLE
Add instructions for VPP tonemapping on Intel

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -299,7 +299,7 @@ Stream #0:2 -> #0:1 (ac3 (native) -> aac (native))
 
 ### Configuring OpenCL Accelerated/VPP Tone Mapping
 
-OpenCL tone mapping with Nvidia NVENC, AMD AMF and Intel VAAPI is through OpenCL image support.
+OpenCL tone mapping with Nvidia NVENC, AMD AMF, and Intel VAAPI is through OpenCL image support.
 
 Full hardware based VPP tonemapping is supported on Intel VAAPI and QSV on Linux.
 
@@ -339,9 +339,9 @@ Docker      | OK           | untested | OK          | planned   | planned   | pl
 
    - For Intel iGPUs, you have two types of tonemapping methods: OpenCL and VPP. Choose the latter one for faster transcoding speed, but fine tuning options are not supported.
 
-    Method OpenCL: follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases). If you are using the docker image from jellyfin/jellyfin and linuxserver/jellyfin, this step can be skipped.
+    Method OpenCL: Follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases). If you are using the docker image from jellyfin/jellyfin or linuxserver/jellyfin, this step can be skipped.
 
-    Method VPP: install `intel-media-va-driver-non-free` 20.1, `jellyfin-ffmpeg` 4.3.1-4 or newer.
+    Method VPP: Install `intel-media-va-driver-non-free` 20.1 and `jellyfin-ffmpeg` 4.3.1-4 or newer.
 
    > [!NOTE]
    > Tone mapping on Intel VAAPI and QSV needs an iGPU that supports 10-bit decoding, such as i3-7100 and J4105.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -301,11 +301,11 @@ Stream #0:2 -> #0:1 (ac3 (native) -> aac (native))
 
 OpenCL tone mapping with Nvidia NVENC, AMD AMF and Intel VAAPI is through OpenCL image support.
 
-Full hardware based VPP tonemapping is supported on Intel VAAPI.
+Full hardware based VPP tonemapping is supported on Intel VAAPI and QSV on Linux.
 
 OS/Platform | NVIDIA NVENC | AMD AMF  | Intel VAAPI | AMD VAAPI | Intel QSV | Software
 ----------- | ------------ | -------- | ----------- | --------- | --------- | --------
-Linux       | OK           | OK       | OK          | planned   | planned   | planned
+Linux       | OK           | OK       | OK          | planned   | OK              | planned
 Windows     | OK           | OK       | N/A         | N/A       | planned   | planned
 Docker      | OK           | untested | OK          | planned   | planned   | planned
 
@@ -344,7 +344,7 @@ Docker      | OK           | untested | OK          | planned   | planned   | pl
     Method VPP: install `intel-media-va-driver-non-free` 20.1, `jellyfin-ffmpeg` 4.3.1-4 or newer.
 
    > [!NOTE]
-   > Tone mapping on Intel VAAPI needs an iGPU that supports 10-bit decoding, such as i3-7100 and J4105.
+   > Tone mapping on Intel VAAPI and QSV needs an iGPU that supports 10-bit decoding, such as i3-7100 and J4105.
    > Do not use the `intel-opencl-icd` package from the repository since they were not build with RELEASE_WITH_REGKEYS enabled for P010 pixel interop flags.
 
 3. Check the OpenCL device status. You will see corresponding vendor name if it goes well.

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -305,7 +305,7 @@ Full hardware based VPP tonemapping is supported on Intel VAAPI and QSV on Linux
 
 OS/Platform | NVIDIA NVENC | AMD AMF  | Intel VAAPI | AMD VAAPI | Intel QSV | Software
 ----------- | ------------ | -------- | ----------- | --------- | --------- | --------
-Linux       | OK           | OK       | OK          | planned   | OK              | planned
+Linux       | OK           | OK       | OK          | planned   | OK        | planned
 Windows     | OK           | OK       | N/A         | N/A       | planned   | planned
 Docker      | OK           | untested | OK          | planned   | planned   | planned
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -297,9 +297,11 @@ Stream #0:0 -> #0:0 (h264 (h264_cuvid) -> h264 (h264_nvenc))
 Stream #0:2 -> #0:1 (ac3 (native) -> aac (native))
 ```
 
-### Configuring OpenCL Accelerated Tone Mapping
+### Configuring OpenCL Accelerated/VPP Tone Mapping
 
-Currently, tone mapping with Nvidia NVENC, AMD AMF and Intel VAAPI is through OpenCL image support.
+OpenCL tone mapping with Nvidia NVENC, AMD AMF and Intel VAAPI is through OpenCL image support.
+
+Full hardware based VPP tonemapping is supported on Intel VAAPI.
 
 OS/Platform | NVIDIA NVENC | AMD AMF  | Intel VAAPI | AMD VAAPI | Intel QSV | Software
 ----------- | ------------ | -------- | ----------- | --------- | --------- | --------
@@ -335,10 +337,14 @@ Docker      | OK           | untested | OK          | planned   | planned   | pl
     sudo ./amdgpu-pro-install -y --opencl=pal,legacy
     ```
 
-   - For Intel iGPUs, follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases). If you are using the docker image from jellyfin/jellyfin, this step can be skipped.
+   - For Intel iGPUs, you have two types of tonemapping methods: OpenCL and VPP. Choose the latter one for faster transcoding speed, but fine tuning options are not supported.
+
+    Method OpenCL: follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases). If you are using the docker image from jellyfin/jellyfin and linuxserver/jellyfin, this step can be skipped.
+
+    Method VPP: install `intel-media-va-driver-non-free` 20.1, `jellyfin-ffmpeg` 4.3.1-4 or newer.
 
    > [!NOTE]
-   > Tone mapping on Intel VAAPI needs an iGPU that supports 10-bit decoding.
+   > Tone mapping on Intel VAAPI needs an iGPU that supports 10-bit decoding, such as i3-7100 and J4105.
    > Do not use the `intel-opencl-icd` package from the repository since they were not build with RELEASE_WITH_REGKEYS enabled for P010 pixel interop flags.
 
 3. Check the OpenCL device status. You will see corresponding vendor name if it goes well.


### PR DESCRIPTION
Instructions for VPP tonemapping from https://github.com/jellyfin/jellyfin/pull/5107