### PR TITLE
fixed comment in the apache reverse proxy guide

### DIFF
--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -47,7 +47,7 @@ title: Apache
     SSLCipherSuite HIGH:RC4-SHA:AES128-SHA:!aNULL:!MD5
     SSLHonorCipherOrder on
 
-    Disable insecure SSL and TLS versions
+    # Disable insecure SSL and TLS versions
     SSLProtocol all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1
 
     ErrorLog /var/log/apache2/DOMAIN_NAME-error.log


### PR DESCRIPTION
I believe line 50 in the apache reverse proxy page should be commented. Otherwise it is not valid syntax and apache will throw the following error:
`
AH00526: Syntax error on line 40 of /etc/apache2/sites-enabled/000-default.conf:
`
`
Invalid command 'Disable', perhaps misspelled or defined by a module not included in the server configuration
`

Commenting this line out fixes the issue for me.