### PR TITLE
notes on hardware accel with AMD Ryzen/Zen

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -35,7 +35,7 @@ List of supported codecs for [VAAPI](https://wiki.archlinux.org/index.php/Hardwa
 AMF is now available on Windows and Linux, but since AMD has not implemented the HW decoder and scaler in ffmpeg, the decoding speed may not be as expected. The closed source driver `amdgpu-pro` is required when using AMF on Linux.
 
 > [!NOTE]
-> Zen is CPU only. No hardware acceleration for any form of video decoding/encoding. You will need an APU or dGPU for hardware acceleration.
+> Most Zen CPUs do not come with integrated graphics. You will need a dedicated GPU (DGPU) for hardware acceleration. If your Zen CPU is suffixed with a "G" or "GE" in model name, you have integrated graphics.
 
 ## Intel QuickSync
 

--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -35,7 +35,7 @@ List of supported codecs for [VAAPI](https://wiki.archlinux.org/index.php/Hardwa
 AMF is now available on Windows and Linux, but since AMD has not implemented the HW decoder and scaler in ffmpeg, the decoding speed may not be as expected. The closed source driver `amdgpu-pro` is required when using AMF on Linux.
 
 > [!NOTE]
-> Most Zen CPUs do not come with integrated graphics. You will need a dedicated GPU (DGPU) for hardware acceleration. If your Zen CPU is suffixed with a "G" or "GE" in model name, you have integrated graphics.
+> Most Zen CPUs do not come with integrated graphics. You will need a dedicated GPU (dGPU) or a Zen CPU with integrated graphics for hardware acceleration. If your Zen CPU is suffixed with a "G" or "GE" in model name, you have integrated graphics.
 
 ## Intel QuickSync
 


### PR DESCRIPTION
This is a confusing statement. An APU *is* part of the same die. It's a confusing term AMD has planted on their chips. It's just an integrated GPU. The exact same as Intel HD/UHD or Iris/Iris Pro. Saying you need an APU while also saying Zen doesn't have them is incorrect. They do have them. Just only a select few. Where as Intel has them on almost all their chips. Xeon, Core, Celeron, etc. Perhaps you could incorporate one of these links that helps readers out. 

https://www.amd.com/en/processors/ryzen-with-graphics

https://www.amd.com/en/products/embedded-g-series

Oh and if readers want to run jellyfin off a laptop, for some reason, mobile Zen CPUs have integrated graphics as well. These are U and HS/HX.