### PR TITLE
Move jellycon repo to org

### DIFF
--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -273,7 +273,7 @@ Kodi thin client for Jellyfin. This addon is fully dynamic and allows for fast u
 
 **Links:**
 
-- [GitHub](https://github.com/mcarlton00/jellycon)
+- [GitHub](https://github.com/jellyfin/jellycon)
 
 ## LG WebOS
 


### PR DESCRIPTION
This has been moved from my personal account to the org, so update the URL on the clients page.