### PR TITLE
KnownProxies now supports hostnames too

### DIFF
--- a/general/networking/index.md
+++ b/general/networking/index.md
@@ -106,7 +106,7 @@ Ports 80 and 443 (pointing to the proxy server) need to be opened on your router
 
 ### Known Proxies
 
-Add the IP address of your reverse proxy to the `Known Proxies` (under Admin Dashboard -> Networking).  This is a comma separated list of IP addresses of known proxies used when connecting to your Jellyfin instance and is required to make proper use of X-Forwarded-For headers. Requires a server restart after saving.
+Add the IP address/hostname of your reverse proxy to the `Known Proxies` (under Admin Dashboard -> Networking).  This is a comma separated list of IP addresses/hostnames of known proxies used when connecting to your Jellyfin instance and is required to make proper use of X-Forwarded-For headers. Requires a server restart after saving.
 
 ### Base URL
 


### PR DESCRIPTION
Per https://github.com/jellyfin/jellyfin/pull/4675 hostnames are supported in the KnownProxies field.