### PR TITLE
Correct web socket nginx proxy config

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -88,7 +88,7 @@ server {
 
     location /socket {
         # Proxy Jellyfin Websockets traffic
-        proxy_pass http://$jellyfin:8096;
+        proxy_pass http://$jellyfin:8096/socket;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Without the /socket, syncplay will not work on jellyfin-web in 10.7