### PR TITLE
Rename MPV Shim and update links.

### DIFF
--- a/general/clients/codec-support.md
+++ b/general/clients/codec-support.md
@@ -11,7 +11,7 @@ The goal is to Direct Play all media. This means the container, video, audio and
 
 [Breakdown of video codecs.](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)
 
-|Sorted by efficency (excluding bit depth)|Chrome|Firefox|Safari|Android|iOS|AndroidTV|[Roku](https://developer.roku.com/docs/specs/streaming.md)|Kodi|[MPV Shim](https://docs.jellyfin.org/general/clients/index.html#jellyfin-mpv-shim)|
+|Sorted by efficency (excluding bit depth)|Chrome|Firefox|Safari|Android|iOS|AndroidTV|[Roku](https://developer.roku.com/docs/specs/streaming.md)|Kodi|[Desktop](https://docs.jellyfin.org/general/clients/index.html#jellyfin-desktop)|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 |[MPEG-4 Part 2/SP](https://en.wikipedia.org/wiki/DivX)|❌|❌|❌|❌||❌|✅|✅|✅|
 |[MPEG-4 Part 2/ASP](https://en.wikipedia.org/wiki/MPEG-4_Part_2#Advanced_Simple_Profile_(ASP))|❌|❌|❌|❌||❌||✅|✅|
@@ -46,7 +46,7 @@ The goal is to Direct Play all media. This means the container, video, audio and
 
 If the audio codec is unsupported or incompatible (such as playing a 5.1 channel stream on a stereo device), the audio codec must be transcoded. This is not nearly as intensive as video transcoding.
 
-||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Roku|Kodi|MPV Shim|
+||Chrome|Firefox|Safari|Android|AndroidTV|iOS|Roku|Kodi|Desktop|
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 |FLAC|✅|✅|✅|✅|||✅|✅|✅|
 |MP3|🔶<sup>1</sup>|🔶|✅|✅|||✅|✅|✅|

--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -133,9 +133,9 @@ Provides both a desktop client mode and background cast mode. The client has sup
 
 **Links:**
 
-* [Github](https://github.com/jellyfin/jellyfin-desktop)
-* [Windows Release](https://github.com/jellyfin/jellyfin-desktop/releases)
-* [Flathub](https://flathub.org/apps/details/com.github.iwalton3.jellyfin-mpv-shim)
+- [Github](https://github.com/jellyfin/jellyfin-desktop)
+- [Windows Release](https://github.com/jellyfin/jellyfin-desktop/releases)
+- [Flathub](https://flathub.org/apps/details/com.github.iwalton3.jellyfin-mpv-shim)
 
 ### Jellycli
 

--- a/general/clients/index.md
+++ b/general/clients/index.md
@@ -125,17 +125,17 @@ Xamarin cross-platform client for Jellyfin.
 
 - [GitHub](https://github.com/chaosinnovator/jellyfin-xamarin)
 
-### Jellyfin MPV Shim
+### Jellyfin Desktop
 
-Provides both a desktop client mode and background cast mode. The client has support for direct play of advanced codecs such as 10 bit HEVC with subtitles, many customizable options, and whole-season subtitle preference support.
+Provides both a desktop client mode and background cast mode. The client has support for direct play of advanced codecs such as 10 bit HEVC with subtitles, many customizable options, and whole-season subtitle preference support. Formerly known as MPV Shim.
 
-**Status:** ⭐ Active, 3rd-Party
+**Status:** ⭐ Active
 
 **Links:**
 
-- [GitHub](https://github.com/iwalton3/jellyfin-mpv-shim)
-- [Flatpak](https://flathub.org/apps/details/com.github.iwalton3.jellyfin-mpv-shim)
-- [Windows](https://github.com/iwalton3/jellyfin-mpv-shim/releases)
+* [Github](https://github.com/jellyfin/jellyfin-desktop)
+* [Windows Release](https://github.com/jellyfin/jellyfin-desktop/releases)
+* [Flathub](https://flathub.org/apps/details/com.github.iwalton3.jellyfin-mpv-shim)
 
 ### Jellycli
 


### PR DESCRIPTION
This updates the Jellyfin documentation to have the new links for Jellyfin Desktop (Formerly MPV Shim).