### PR TITLE
Update apache.md

### DIFF
--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -11,8 +11,8 @@ title: Apache
 <VirtualHost *:80>
     ServerName DOMAIN_NAME
 
-    # Uncomment for HTTP to HTTPS redirect
-    # Redirect permanent / https://DOMAIN_NAME
+    # Comment to prevent HTTP to HTTPS redirect
+    Redirect permanent / https://DOMAIN_NAME
 
     ErrorLog /var/log/apache2/DOMAIN_NAME-error.log
     CustomLog /var/log/apache2/DOMAIN_NAME-access.log combined
@@ -30,7 +30,7 @@ title: Apache
 
     # Letsencrypt's certbot will place a file in this folder when updating/verifying certs
     # This line will tell apache to not to use the proxy for this folder.
-    ProxyPass /.well_known/ !
+    ProxyPass "/.well-known/" "!"
 
     ProxyPass "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
     ProxyPassReverse "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"


### PR DESCRIPTION
HTTPS may be enabled by default as certbot will check _/var/www/html/jellyfin/public_html/.well_known_/ path which is not defined in _<VirtualHost *:80>_.
LetsEncrypt challenges are in **.well-known** dir, not **_.well_known_**.
ProxyPass exception may respect syntax with apostrophe.