### PR TITLE
Added note for installing certbot on Fedora based distributions

### DIFF
--- a/general/networking/letsencrypt.md
+++ b/general/networking/letsencrypt.md
@@ -102,6 +102,8 @@ Add a job to cron so the certificate will be renewed automatically.
 
 After installing Certbot and the Nginx plugin with `sudo apt install certbot python3-certbot-nginx`, generate the certificate.
 
+**Note**: For Fedora Linux distributions (E.g. CentOS 8) use `sudo dnf install python3-certbot-nginx` to install the Nginx plugin.
+
 ```sh
 sudo certbot --nginx --agree-tos --redirect --hsts --staple-ocsp --email YOUR_EMAIL -d DOMAIN_NAME
 ```

--- a/general/networking/letsencrypt.md
+++ b/general/networking/letsencrypt.md
@@ -102,7 +102,7 @@ Add a job to cron so the certificate will be renewed automatically.
 
 After installing Certbot and the Nginx plugin with `sudo apt install certbot python3-certbot-nginx`, generate the certificate.
 
-**Note**: For Fedora Linux distributions (E.g. CentOS 8) use `sudo dnf install python3-certbot-nginx` to install the Nginx plugin.
+**Note**: For Fedora Linux distributions (e.g. CentOS 8) use `sudo dnf install python3-certbot-nginx` to install the Nginx plugin.
 
 ```sh
 sudo certbot --nginx --agree-tos --redirect --hsts --staple-ocsp --email YOUR_EMAIL -d DOMAIN_NAME


### PR DESCRIPTION
Minor addition to add `dnf` command option for installing certbot on Fedora distributions such as CentOS 8