### PR TITLE
additional info for show images

### DIFF
--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -26,3 +26,55 @@ Shows
 
 > [!NOTE]
 > Season folders shouldn't contain the series name, otherwise Jellyfin can in certain cases (Stargate SG-1 due to the dash and one, for instance) misdetect your episodes and put them all under the same season.
+
+
+## Images
+
+### Poster
+* folder.ext
+* poster.ext
+* cover.ext
+* default.ext
+
+Examples:
+
+Series (2010)/poster.jpg _for series or movie poster_
+
+Series (2010)/Season 01/season1-poster.jpg _for season poster_
+
+### Backdrop
+* backdrop.ext
+* fanart.ext
+* background.ext
+* art.ext
+* extrafanart.ext
+
+Examples:
+
+Series (2010)/fanart.jpg _for the first backdrop image_
+
+Series (2010)/extrafanart/fanart1.jpg, Series (2010)/extrafanart/fanart2.jpg, _etc for additional backdrop images_
+
+### Banner
+* banner.ext
+
+Example:
+
+Series (2010)/banner.jpg
+
+### Thumb
+* thumb.ext
+* landscape.ext
+
+Examples:
+
+Series (2010)/landscape.jpg
+
+Series (2010)/Season 01/episode filename-thumb.jpg _for the thumbnail of an episode named "episode filename.mkv"_
+
+### Logo
+* logo.ext
+
+Example:
+
+Series (2010)/logo.png

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -38,9 +38,9 @@ Shows
 
 Examples:
 
-Series (2010)/poster.jpg _for series or movie poster_
+Series (2010)/poster.jpg *for series or movie poster*
 
-Series (2010)/Season 01/season1-poster.jpg _for season poster_
+Series (2010)/Season 01/season1-poster.jpg *for season poster*
 
 ### Backdrop
 

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -27,7 +27,6 @@ Shows
 > [!NOTE]
 > Season folders shouldn't contain the series name, otherwise Jellyfin can in certain cases (Stargate SG-1 due to the dash and one, for instance) misdetect your episodes and put them all under the same season.
 
-
 ## Images
 
 ### Poster

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -52,9 +52,9 @@ Series (2010)/Season 01/season1-poster.jpg *for season poster*
 
 Examples:
 
-Series (2010)/fanart.jpg _for the first backdrop image_
+Series (2010)/fanart.jpg *for the first backdrop image*
 
-Series (2010)/extrafanart/fanart1.jpg, Series (2010)/extrafanart/fanart2.jpg, _etc for additional backdrop images_
+Series (2010)/extrafanart/fanart1.jpg, Series (2010)/extrafanart/fanart2.jpg, *etc for additional backdrop images*
 
 ### Banner
 
@@ -73,7 +73,7 @@ Examples:
 
 Series (2010)/landscape.jpg
 
-Series (2010)/Season 01/episode filename-thumb.jpg _for the thumbnail of an episode named "episode filename.mkv"_
+Series (2010)/Season 01/episode filename-thumb.jpg *for the thumbnail of an episode named "episode filename.mkv"*
 
 ### Logo
 

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -31,6 +31,7 @@ Shows
 ## Images
 
 ### Poster
+
 * folder.ext
 * poster.ext
 * cover.ext
@@ -43,6 +44,7 @@ Series (2010)/poster.jpg _for series or movie poster_
 Series (2010)/Season 01/season1-poster.jpg _for season poster_
 
 ### Backdrop
+
 * backdrop.ext
 * fanart.ext
 * background.ext
@@ -56,6 +58,7 @@ Series (2010)/fanart.jpg _for the first backdrop image_
 Series (2010)/extrafanart/fanart1.jpg, Series (2010)/extrafanart/fanart2.jpg, _etc for additional backdrop images_
 
 ### Banner
+
 * banner.ext
 
 Example:
@@ -63,6 +66,7 @@ Example:
 Series (2010)/banner.jpg
 
 ### Thumb
+
 * thumb.ext
 * landscape.ext
 
@@ -73,6 +77,7 @@ Series (2010)/landscape.jpg
 Series (2010)/Season 01/episode filename-thumb.jpg _for the thumbnail of an episode named "episode filename.mkv"_
 
 ### Logo
+
 * logo.ext
 
 Example:


### PR DESCRIPTION
added additional information for images in show folders, 
information taken from the following reddit post by u/linetrimmer [https://www.reddit.com/r/jellyfin/comments/m8aqlt/external_cover_images/grhw63z/?context=3]
as well as the existing docs from the "Music" section

TODO: could be expanded with table like in main headline to show the files in the file structure.