### PR TITLE
Kodi native mode with mounted shares

### DIFF
--- a/general/clients/kodi.md
+++ b/general/clients/kodi.md
@@ -90,7 +90,7 @@ To use Native mode, first set up your libraries in Jellyfin with a remote path.
             * If you have mounted your network share, you can reference the local mount point. This can be more performant but generally means it only works for one type of operating system, given the difference between the file systems
                 * `/mnt/media` (Linux)
                 * `Z:\media` (Windows)
-                * `/Volumes/media` (OS X)
+                * `/Volumes/media` (Mac OS)
 2. Configure libraries in Kodi
     * Skip the initial library selection.  We need to add file shares to Kodi first
     * Within Kodi, navigate to the settings menu and select "File manager"

--- a/general/clients/kodi.md
+++ b/general/clients/kodi.md
@@ -86,12 +86,18 @@ To use Native mode, first set up your libraries in Jellyfin with a remote path.
             * Guest User - `\\192.168.0.10\share_name`
             * Custom User (Not Recommended) - `\\user:password@192.168.0.10\share_name`
                 * It's more secure to use the generic Guest mapping here and specify credentials from within Kodi
+        * Mounted share
+            * If you have mounted your network share, you can reference the local mount point. This can be more performant but generally means it only works for one type of operating system, given the difference between the file systems
+                * `/mnt/media` (Linux)
+                * `Z:\media` (Windows)
+                * `/Volumes/media` (OS X)
 2. Configure libraries in Kodi
     * Skip the initial library selection.  We need to add file shares to Kodi first
     * Within Kodi, navigate to the settings menu and select "File manager"
     * Select "Add source"
     * Select "Browse" and "Add network location"
     * Create either a NFS or SMB location from the selection box and fill in the necessary information about your network share
+      * If you are using a mounted share, browse to the mount point on your file system rather than the network share
     * Select your newly created location and choose "Ok"
     * Give your media source a name and choose "Ok"
     * Go to Add-Ons -> Jellyfin -> Manage Libraries -> Add Libraries


### PR DESCRIPTION
Mounted shares can be referenced in the library and can be beneficial from a performance standpoint since it’s offloaded to the OS directly.
This is a popular approach on “low end” Kodi clients, like Raspberry Pi for instance.

The downside of using mounts is that the mount point is not interoperable between different operating systems.

How to actually mount a share is way outside the scope of this documentation, but I added some examples from different operating systems.

### Screenshot
<img width="689" alt="Screenshot 2021-03-20 at 15 31 16" src="https://user-images.githubusercontent.com/28260/111873605-6d2f1f00-8991-11eb-972f-7d7d3feb1f50.png">


---

### Personal notes

I'm a very recent adopter of Jellyfin and didn't consider I could just reuse my existing mounts when doing the setup. It crossed my mind though, but I stuck to the suggested guide and added a new network share. It was still a bit slower then my previously mounted SMB share, so when I got some free time I wanted to try it out.

I now use a NFS mount on a Debian based Vero 4K+ (local network) and playback is practically instant no matter the file size.

_In theory_, my remote clients could also do native mode (probably discouraged) on a Webdav mount, to maximize the ~bandwidth~ throughput on "lower end" clients. This is something I haven't tested yet, but I'm excited about the possibility.

I also haven't used Windows in a decade and haven't been able to verify the syntax of the Windows share point. I suspect this approach is more popular among Linux distributions anyway.