### PR TITLE
Document the /metrics Prometheus endpoint

### DIFF
--- a/general/networking/index.md
+++ b/general/networking/index.md
@@ -44,13 +44,9 @@ Allows clients to discover Jellyfin on the local network. A broadcast message to
 
 Live TV devices will often use a random UDP port for HDHomeRun devices. The server will select an unused port on startup to connect to these tuner devices.
 
-### Health Check Endpoint
+### Monitoring Endpoints
 
-Jellyfin exposes the `/health` endpoint designated for checking the status of the underlying service. Currently this will verify HTTP and database connectivity and return a `200 OK` response if successful.
-
-```sh
-curl http://myserver:8096/health
-```
+See @monitoring for details on the monitoring endpoints that Jellyfin provides.
 
 ## Self-Signed Certificate
 

--- a/general/networking/monitoring.md
+++ b/general/networking/monitoring.md
@@ -1,0 +1,30 @@
+---
+uid: monitoring
+title: Monitoring
+---
+
+## Monitoring
+
+Jellyfin has two monitoring and metrics endpoints built-in: a basic health check endpoint and a Prometheus-compatible metrics endpoint.
+
+### Health check endpoint
+
+Jellyfin exposes the `/health` endpoint designated for checking the status of the underlying service. Currently this will verify HTTP and database connectivity and return a `200 OK` response if successful. You can see this for yourself by using `curl`:
+
+```sh
+curl -i http://myserver:8096/health
+```
+
+The `-i` option tells `curl` to also print the HTTP response code and headers.
+
+### Prometheus metrics
+
+Jellyfin can make [Prometheus](https://prometheus.io/) metrics available at `/metrics`, but this is turned off by default to avoid unintentionally leaking this information on the public internet. To enable it, you will need to edit `/etc/jellyfin/system.xml` and change this line:
+
+```xml
+<EnableMetrics>false</EnableMetrics>
+```
+
+to say `true` instead of `false`.
+
+If you have a [reverse proxy](xref:network-index#running-jellyfin-behind-a-reverse-proxy) configured, you can configure it to block access to the `/metrics` endpoint except for your internal network.

--- a/general/networking/monitoring.md
+++ b/general/networking/monitoring.md
@@ -19,12 +19,10 @@ The `-i` option tells `curl` to also print the HTTP response code and headers.
 
 ### Prometheus metrics
 
-Jellyfin can make [Prometheus](https://prometheus.io/) metrics available at `/metrics`, but this is turned off by default to avoid unintentionally leaking this information on the public internet. To enable it, you will need to edit `/etc/jellyfin/system.xml` and change this line:
+Jellyfin can make [Prometheus](https://prometheus.io/) metrics available at `/metrics`, but this is turned off by default to avoid unintentionally leaking this information on the public internet. To enable it, you will need to edit `/etc/jellyfin/system.xml` and change this line from `false` to `true`:
 
 ```xml
 <EnableMetrics>false</EnableMetrics>
 ```
-
-to say `true` instead of `false`.
 
 If you have a [reverse proxy](xref:network-index#running-jellyfin-behind-a-reverse-proxy) configured, you can configure it to block access to the `/metrics` endpoint except for your internal network.

--- a/index.md
+++ b/index.md
@@ -51,6 +51,7 @@ Want to know more about administering a Jellyfin server? Check out these pages!
 * [Migrating from Emby](xref:admin-migrate-from-emby): How to migrate an existing Emby 3.5.2 installation to Jellyfin.
 * [Plugins](xref:server-plugins-index): How to install and manage plugins.
 * [Networking](xref:network-index): Networking settings and troubleshooting.
+* [Monitoring](xref:monitoring): Integration with external monitoring software.
 * [Hardware Acceleration](xref:admin-hardware-acceleration): Improve transcoding performance on supported hardware.
 
 ## Contributing to Jellyfin


### PR DESCRIPTION
I made a new page specifically for monitoring and moved the `/health` endpoint documentation into it as well as this new Prometheus documentation. (I'm kinda lumping metrics and monitoring together, but that seems fine.)