### PR TITLE
Add warning and example about api_key parameters in logfiles

### DIFF
--- a/general/networking/index.md
+++ b/general/networking/index.md
@@ -79,7 +79,7 @@ It's possible to run Jellyfin behind another server acting as a reverse proxy.  
 > These examples assume you want to run Jellyfin under a sub-domain (e.g. jellyfin.example.com), but are easily adapted for the root domain if desired.
 
 > [!WARNING]
-> Be careful when logging requests with your reverse proxy. Jellyfin sometimes sends authentication information as part of the URL, so logging the full request
+> Be careful when logging requests with your reverse proxy. Jellyfin sometimes sends authentication information as part of the URL (e.g <code>api_key</code> parameter), so logging the full request
 > path can expose secrets to your logfile. We recommend that you either protect your logfiles or do not log full request URLs or censor sensitive data from the logfile.
 > The nginx documentation below includes an example how to censor sensitive information from a logfile.
 

--- a/general/networking/index.md
+++ b/general/networking/index.md
@@ -78,6 +78,12 @@ It's possible to run Jellyfin behind another server acting as a reverse proxy.  
 > In order for a reverse proxy to have the maximum benefit, you should have a publically routable IP address and a domain with DNS set up correctly.
 > These examples assume you want to run Jellyfin under a sub-domain (e.g. jellyfin.example.com), but are easily adapted for the root domain if desired.
 
+> [!WARNING]
+> Be careful when logging requests with your reverse proxy. Jellyfin sometimes sends authentication information as part of the URL, so logging the full request
+> path can expose secrets to your logfile. We recommend that you either protect your logfiles or do not log full request URLs or censor sensitive data from the logfile.
+> The nginx documentation below includes an example how to censor sensitive information from a logfile.
+
+
 Some popular options for reverse proxy systems are [Apache](https://httpd.apache.org), [Caddy](https://caddyserver.com), [Haproxy](https://www.haproxy.com), [Nginx](https://www.nginx.com) and [Traefik](https://traefik.io).
 
 * [Apache](xref:network-reverse-proxy-apache)

--- a/general/networking/index.md
+++ b/general/networking/index.md
@@ -83,7 +83,6 @@ It's possible to run Jellyfin behind another server acting as a reverse proxy.  
 > path can expose secrets to your logfile. We recommend that you either protect your logfiles or do not log full request URLs or censor sensitive data from the logfile.
 > The nginx documentation below includes an example how to censor sensitive information from a logfile.
 
-
 Some popular options for reverse proxy systems are [Apache](https://httpd.apache.org), [Caddy](https://caddyserver.com), [Haproxy](https://www.haproxy.com), [Nginx](https://www.nginx.com) and [Traefik](https://traefik.io).
 
 * [Apache](xref:network-reverse-proxy-apache)

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -191,7 +191,6 @@ map $request $secretfilter {
 access_log /var/log/nginx/access.log stripsecrets;
 ```
 
-
 ### Cache Video Streams
 
 ```conf

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -170,7 +170,7 @@ server {
 
 ## Extra Nginx Configurations
 
-## Censor sensitive information in logs
+### Censor sensitive information in logs
 
 This censors any <code>api_key</code> URL parameter from the logfile.
 

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -170,6 +170,28 @@ server {
 
 ## Extra Nginx Configurations
 
+## Censor sensitive information in logs
+
+This censors any <code>api_key</code> URL parameter from the logfile.
+
+```conf
+#Must be in HTTP block
+log_format stripsecrets '$remote_addr $host - $remote_user [$time_local] '
+                    '"$secretfilter" $status $body_bytes_sent '
+                    '$request_length $request_time $upstream_response_time '
+                    '"$http_referer" "$http_user_agent"';
+                    
+map $request $secretfilter {
+    ~*^(?<prefix1>.*[\?&]api_key=)([^&]*)(?<suffix1>.*)$  "${prefix1}***$suffix1";
+    default                                               $request;
+}
+
+#Must be inside server block
+#Insert into all servers where you want filtering (e.g HTTP + HTTPS block)
+access_log /var/log/nginx/access.log stripsecrets;
+```
+
+
 ### Cache Video Streams
 
 ```conf


### PR DESCRIPTION
Relates to this issue: https://github.com/jellyfin/jellyfin/issues/5415

This tells users that they should be aware about what they're logging and for nginx only it includes an example on how to filter such information. I do not know the other webservers well enough to write examples for these from scratch.