### PR TITLE
feat: Point users to Extrepo based install for Debian

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -591,10 +591,10 @@ The Jellyfin team provides a Debian repository for installation on Debian Stretc
 
 Steps 1 to 3 can also be replaced by:
 
-    ```sh
-    sudo apt install extrepo
-    sudo extrepo enable jellyfin
-    ```
+```sh
+sudo apt install extrepo
+sudo extrepo enable jellyfin
+```
 
 1. Install HTTPS transport for APT as well as `gnupg` and `lsb-release` if you haven't already.
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -589,6 +589,13 @@ The Jellyfin team provides a Debian repository for installation on Debian Stretc
 > [!NOTE]
 > Microsoft does not provide a .NET for 32-bit x86 Linux systems, and hence Jellyfin is not supported on the `i386` architecture.
 
+Steps 1 to 3 can also be replaced by:
+
+    ```sh
+    sudo apt install extrepo
+    sudo extrepo enable jellyfin
+    ```
+
 1. Install HTTPS transport for APT as well as `gnupg` and `lsb-release` if you haven't already.
 
     ```sh

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -255,7 +255,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
 4. Enable the service.
 
     ```sh
-    systemctl --user enable container-myjellyfin.service 
+    systemctl --user enable container-myjellyfin.service
     ```
 
     At this point the container will only start when the user logs in and shutdown when they log off. To have the container start as the user at first login we'll have to include one more option.
@@ -267,7 +267,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
 5. Start the service.
 
     ```sh
-    systemctl --user start container-myjellyfin.service 
+    systemctl --user start container-myjellyfin.service
     ```
 
 ### Cloudron


### PR DESCRIPTION
The [suggested way to install Jellyfin on Debian](https://jellyfin.org/docs/general/administration/installing.html#debian) involves downloading the signing key from the same webserver that the repo is served from without pinning the key by fingerprint or the like.

[Extrepo](https://salsa.debian.org/extrepo-team/extrepo) exists to address this problem. It has the advantage of being in Debian (and Ubuntu) so there is a trust chain for the user that can be publicly reviewed.

This PR proposes switching to an Extrepo based install method. Note that [I added Jellyfin to extrepo-data](https://salsa.debian.org/extrepo-team/extrepo-data/-/merge_requests/72) so you might need to discuss if Extrepo is suitable for you here as Extrepo is unknown so far in the Jellyfin community as far as I can tell (and I have not mentioned it earlier).

* https://grep.be/blog/en/computer/debian/Announcing_extrepo/