### PR TITLE
Update migrate-from-emby.md

### DIFF
--- a/general/administration/migrate-from-emby.md
+++ b/general/administration/migrate-from-emby.md
@@ -66,7 +66,7 @@ This procedure is written for Debian-based Linux distributions, but can be trans
    sudo chown -R jellyfin:jellyfin /var/lib/jellyfin
    ```
 
-9. Mark Startup Wizard as completed - if not marked as completed then it can be a security risk specially if remote access is enabled:
+9. Mark Startup Wizard as completed - if not marked as completed then it can be a security risk especially if remote access is enabled:
 
    ```sh
    sudo sed -i '/IsStartupWizardCompleted/s/false/true/' /etc/jellyfin/system.xml

--- a/general/administration/migrate-from-emby.md
+++ b/general/administration/migrate-from-emby.md
@@ -66,7 +66,13 @@ This procedure is written for Debian-based Linux distributions, but can be trans
    sudo chown -R jellyfin:jellyfin /var/lib/jellyfin
    ```
 
-9. Start the `jellyfin` daemon:
+9. Mark Startup Wizard as completed - if not marked as completed then it can be a security risk specially if remote access is enabled:
+
+   ```sh
+   sudo sed -i '/IsStartupWizardCompleted/s/false/true/' /etc/jellyfin/system.xml
+   ```
+
+10. Start the `jellyfin` daemon:
 
    ```sh
    sudo service jellyfin start


### PR DESCRIPTION
After completing documented steps, Jellyfin opens Startup Wizard with no need to authenticate. If that Wizard is completed, last user created (in library prior to migration) will be overwritten. This is a security risk as anyone who can open the web interface can overwrite a user and gain unwanted access to Jellyfin, very bad if web interface is allowed via remote access on the Internet. I have added step "Mark Startup Wizard as completed" to prevent Jellyfin from opening Startup Wizard.