### PR TITLE
Update apache.md

### DIFF
--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -56,8 +56,8 @@ title: Apache
 </IfModule>
 ```
 
-If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel` and `remoteip` support manually.
+If you encouter errors, you may have to enable `mod_proxy`, `mod_ssl`, `proxy_wstunnel`, `http2` and `remoteip` support manually.
 
 ```bash
-sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip
+sudo a2enmod proxy proxy_http ssl proxy_wstunnel remoteip http2
 ```


### PR DESCRIPTION
Adding the "http2" module to enable in apache2 in order to get the instruction "Protocols" running. Without this module, applications of Jellyfin will not work in https.