### PR TITLE
Use a newer version of DocFX

### DIFF
--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,5 +1,6 @@
-nuget install docfx.console -Verbosity detailed
-docfx.exe --warningsAsErrors docfx.json
+nuget install docfx.console
+cd .\docfx.console*\tools\
+.\docfx.exe --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")
 }

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,4 +1,4 @@
-choco install docfx -y
+nuget.exe install docfx.console
 docfx --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,6 +1,5 @@
 nuget install docfx.console
-cd .\docfx.console*\tools\
-.\docfx.exe --warningsAsErrors docfx.json
+.\docfx.console*\tools\docfx.exe --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")
 }

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,5 +1,5 @@
 nuget install docfx.console
-.\docfx.console*\tools\docfx.exe --warningsAsErrors docfx.json
+.\docfx.console*\tools\docfx.exe docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")
 }

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,4 +1,4 @@
-choco install docfx -y --version 2.48.1
+choco install docfx -y
 docfx --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,4 +1,4 @@
-nuget.exe install docfx.console
+nuget install docfx
 docfx --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")

--- a/.ci/build-in-ci.ps1
+++ b/.ci/build-in-ci.ps1
@@ -1,5 +1,5 @@
-nuget install docfx
-docfx --warningsAsErrors docfx.json
+nuget install docfx.console -Verbosity detailed
+docfx.exe --warningsAsErrors docfx.json
 if ($lastexitcode -ne 0){
     throw ("Error generating document")
 }


### PR DESCRIPTION
Unpins from 2.48.1, and just use the latest stable release instead. This will help us avoid errors with the .NET SDK moving forward in version updates, breaking compat with the older version of DocFX.