### PR TITLE
Update hardware-acceleration.md

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -440,6 +440,9 @@ AMD does not provide official `amdgpu-pro` driver support for Arch Linux, but fo
 > RPi4 currently doesn't support HWA HEVC decoding, only encode and decode H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for transcoding. Only Raspbian OS works so far. For docker, only the linuxserver image works. For more tips see [here](https://www.reddit.com/r/jellyfin/comments/ei6ew6/rpi4_hardware_acceleration_guide/).
 
 > [!NOTE]
+> As per [this issue](https://github.com/jellyfin/jellyfin/issues/4023), hardware acceleration is not yet supported on 64-bit Raspberry Pi OS (and likely on derivative builds e.g. DietPi), as some libraries in the 32-bit build are still missing from the 64-bit build.
+
+> [!NOTE]
 > For RPi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.
 
 ## Verifying Transcodes


### PR DESCRIPTION
Adding a note that hardware acceleration will not work on Raspberry Pi OS 64-bit