### PR TITLE
Added note about using a variable 'chain=DOCKER-USER' when jellyfin is running in a docker-container

### DIFF
--- a/general/networking/fail2ban.md
+++ b/general/networking/fail2ban.md
@@ -43,6 +43,16 @@ logpath = /var/log/jellyfin/jellyfin*.log
 
 Save and exit nano.
 
+Note:
+
+1. If jellyfin is running in a docker container, then add the following to jellyfin.local file
+
+    ```bash
+    action = iptables-allports[name=jellyin, chain=DOCKER-USER]
+    ```
+
+2. If you are running Jellyfin on a non-standard port, then change the port from 80,443 to the relevant port say 8096 8920
+
 ### Step two: create a filter
 
 The filter explains to Fail2ban where to look in the log file. This is the tricky part.


### PR DESCRIPTION
When running Jellyfin in a docker-container, fail2ban seems to not work unless the following variable is defined in either

1. jail.local
2. jai.d/jellyfin.local


Variable to be defined:
chain=DOCKER-USER


References:
1. https://github.com/fail2ban/fail2ban/issues/2292#issuecomment-522141827
2. https://github.com/dani-garcia/vaultwarden/issues/973#issuecomment-662929152
