### PR TITLE
Change new issue link to go to issue type chooser

### DIFF
--- a/general/contributing/issues.md
+++ b/general/contributing/issues.md
@@ -25,7 +25,7 @@ If the existing issue is closed, please read through it to see if the accepted w
 
 ## Opening an Issue
 
-Once you're ready to open an issue, please [see this page](https://github.com/jellyfin/jellyfin/issues/new)!
+Once you're ready to open an issue, please [see this page](https://github.com/jellyfin/jellyfin/issues/new/choose)!
 
 ### Reporting Bugs
 


### PR DESCRIPTION
Old link directly opened a new issue with no template. Changed it to link to the template chooser so users coming from this page will have a more guided experience writing their first issue.