### PR TITLE
Update Podman example

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -140,7 +140,7 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
 
 ### Podman
 
-[Podman](https://podman.io) allows you to run containers as non-root. It's also the offically supported container solution on RHEL and CentOS.
+[Podman](https://podman.io) allows you to run containers as non-root. It's also the officially supported container solution on RHEL and CentOS.
 
 Steps to run Jellyfin using Podman are almost identical to Docker steps:
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -154,12 +154,12 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
 
    ```sh
    podman run \
-    --volume jellyfin-config:/config:Z \
-    --volume jellyfin-cache:/cache:Z \
-    --volume jellyfin-media:/media:ro,z \
-    --publish 8096:8096/tcp \
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
+    --publish 8096:8096/tcp \
+    --volume jellyfin-cache:/cache:Z \
+    --volume jellyfin-config:/config:Z \
+    --volume jellyfin-media:/media:ro,z \
     docker.io/jellyfin/jellyfin:latest
    ```
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -154,7 +154,6 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
 
    ```sh
    podman run \
-    --cgroup-manager=systemd \
     --volume jellyfin-config:/config \
     --volume jellyfin-cache:/cache \
     --volume jellyfin-media:/media \

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -254,7 +254,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
     At this point the container will only start when the user logs in and shutdown when they log off. To have the container start as the user at first login we'll have to include one more option.
 
     ```sh
-    loginctl enable-linger <username>
+    loginctl enable-linger $USER
     ```
 
 6. To enable Podman auto-updates, enable the necessary Systemd timer. 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -161,7 +161,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     -p 8096:8096 \
     --label "io.containers.autoupdate=image" \
     --name myjellyfin \
-    jellyfin/jellyfin
+    docker.io/jellyfin/jellyfin:latest
    ```
 
 Note that Podman doesn't require root access and it's recommended to run the Jellyfin container as a separate non-root user for security.

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -158,13 +158,20 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     --name myjellyfin \
     --publish 8096:8096/tcp \
     --rm \
+    --user $(id -u):$(id -g) \
+    --userns keep-id \
     --volume jellyfin-cache:/cache:Z \
     --volume jellyfin-config:/config:Z \
     --volume jellyfin-media:/media:ro,z \
     docker.io/jellyfin/jellyfin:latest
    ```
 
-Note that Podman doesn't require root access and it's recommended to run the Jellyfin container as a separate non-root user for security.
+Note that Podman doesn't require root access.
+For security, the Jellyfin container should be run using rootless Podman.
+Furthermore, it is safer to run as a non-root user within the container.
+The `--user` option will run with the provided user id and group id *inside* the container.
+The `--userns keep-id` flag ensures that current user's id is mapped to the non-root user's id inside the container.
+This ensures that the permissions for directories bind-mounted inside the container are mapped correctly between the user running Podman and the user running Jellyfin inside the container.
 
 Keep in mind that the `--label "io.containers.autoupdate=image"` flag will allow the container to be automatically updated via `podman auto-update`.
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -155,7 +155,7 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
     sudo firewall-cmd --reload
     ```
 
-2. Create and run a Jellyfin container:
+3. Create and run a Jellyfin container:
 
    ```sh
    podman run \
@@ -257,7 +257,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
     loginctl enable-linger $USER
     ```
 
-6. To enable Podman auto-updates, enable the necessary Systemd timer. 
+6. To enable Podman auto-updates, enable the necessary Systemd timer.
 
     ```sh
     systemctl --user enable --now podman-auto-update.timer

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -179,11 +179,7 @@ The `z` (shared volume) or `Z` (private volume) volume option to allow Jellyfin 
 
 Replace `jellyfin-config`, `jellyfin-cache`, and `jellyfin-media` with `/path/to/config`, `/path/to/cache` and `/path/to/media` respectively if using bind mounts.
 
-To mount your media library read-only append ':ro' to the media volume:
-
-   ```sh
-   --volume /path/to/media:/media:ro
-   ```
+This example mounts your media library read-only by appending ':ro' to the media volume. Remove this option if you wish to give Jellyfin write access to your media.
 
 #### Managing via Systemd
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -257,7 +257,7 @@ As always it is recommended to run the container rootless. Therefore we want to 
     loginctl enable-linger $USER
     ```
 
-6. To enable Podman auto-updates, enable the necessary Systemd timer.
+6. To enable Podman auto-updates, enable the necessary systemd timer.
 
     ```sh
     systemctl --user enable --now podman-auto-update.timer

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -150,6 +150,13 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
    dnf install -y podman
    ```
 
+2. Open the necessary ports in your machine's firewall to permit access to the Jellyfin server from outside the host. This is necessary for rootless Podman because it won't be able to open these automatically. If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections.  
+
+    ```sh
+    firewall-cmd --add-port=8096/tcp --permanent
+    firewall-cmd --reload
+    ```
+
 2. Create and run a Jellyfin container:
 
    ```sh

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -148,14 +148,7 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
    sudo dnf install -y podman
    ```
 
-2. Open the necessary ports in your machine's firewall to permit access to the Jellyfin server from outside the host. This is necessary for rootless Podman because it won't be able to open these automatically. If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections.  
-
-    ```sh
-    sudo firewall-cmd --add-port=8096/tcp --permanent
-    sudo firewall-cmd --reload
-    ```
-
-3. Create and run a Jellyfin container:
+2. Create and run a Jellyfin container:
 
    ```sh
    podman run \
@@ -171,6 +164,13 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
     --volume jellyfin-media:/media:ro,z \
     docker.io/jellyfin/jellyfin:latest
    ```
+
+3. Open the necessary ports in your machine's firewall if you wish to permit access to the Jellyfin server from outside the host. This is not done automatically when using rootless Podman. If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections.  
+
+    ```sh
+    sudo firewall-cmd --add-port=8096/tcp --permanent
+    sudo firewall-cmd --reload
+    ```
 
 Podman doesn't require root access to run containers.
 For security, the Jellyfin container should be run using rootless Podman.

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -145,14 +145,14 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
 1. Install Podman:
 
    ```sh
-   dnf install -y podman
+   sudo dnf install -y podman
    ```
 
 2. Open the necessary ports in your machine's firewall to permit access to the Jellyfin server from outside the host. This is necessary for rootless Podman because it won't be able to open these automatically. If your distribution uses `firewalld`, the following commands save and load a new firewall rule opening the HTTP port `8096` for TCP connections.  
 
     ```sh
-    firewall-cmd --add-port=8096/tcp --permanent
-    firewall-cmd --reload
+    sudo firewall-cmd --add-port=8096/tcp --permanent
+    sudo firewall-cmd --reload
     ```
 
 2. Create and run a Jellyfin container:

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -159,7 +159,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     --volume jellyfin-cache:/cache \
     --volume jellyfin-media:/media \
     -p 8096:8096 \
-    --label "io.containers.autoupdate=image" \
+    --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
     docker.io/jellyfin/jellyfin:latest
    ```

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -150,29 +150,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
    dnf install -y podman
    ```
 
-2. Download the latest container image:
-
-   ```sh
-   podman pull docker.io/jellyfin/jellyfin
-   ```
-
-3. Create persistent storage for configuration and cache data:
-
-   Either create two persistent volumes:
-
-   ```sh
-   podman volume create jellyfin-config
-   podman volume create jellyfin-cache
-   ```
-
-   Or create two directories on the host and use bind mounts:
-
-   ```sh
-   mkdir /path/to/config
-   mkdir /path/to/cache
-   ```
-
-4. Create and run a Jellyfin container:
+2. Create and run a Jellyfin container:
 
    ```sh
    podman run \

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -157,6 +157,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
     --publish 8096:8096/tcp \
+    --rm \
     --volume jellyfin-cache:/cache:Z \
     --volume jellyfin-config:/config:Z \
     --volume jellyfin-media:/media:ro,z \

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -154,9 +154,9 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
 
    ```sh
    podman run \
-    --volume jellyfin-config:/config \
-    --volume jellyfin-cache:/cache \
-    --volume jellyfin-media:/media \
+    --volume jellyfin-config:/config:Z \
+    --volume jellyfin-cache:/cache:Z \
+    --volume jellyfin-media:/media:ro,z \
     --publish 8096:8096/tcp \
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
@@ -167,7 +167,7 @@ Note that Podman doesn't require root access and it's recommended to run the Jel
 
 Keep in mind that the `--label "io.containers.autoupdate=image"` flag will allow the container to be automatically updated via `podman auto-update`.
 
-If SELinux is enabled you need to use either the `z` (shared volume) or `Z` (private volume) volume option to allow Jellyfin to access the volumes.
+The `z` (shared volume) or `Z` (private volume) volume option to allow Jellyfin to access the volumes on systems where SELinux is enabled.
 
 Replace `jellyfin-config`, `jellyfin-cache`, and `jellyfin-media` with `/path/to/config`, `/path/to/cache` and `/path/to/media` respectively if using bind mounts.
 

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -159,6 +159,7 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
 
    ```sh
    podman run \
+    --detach \
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
     --publish 8096:8096/tcp \

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -233,10 +233,16 @@ As always it is recommended to run the container rootless. Therefore we want to 
     WantedBy=multi-user.target default.target
     ```
 
-4. Enable the service.
+4. Stop the running Jellyfin container.
 
     ```sh
-    systemctl --user enable container-myjellyfin.service
+    podman stop myjellyfin
+    ```
+
+5. Start and enable the service.
+
+    ```sh
+    systemctl --user enable --now container-myjellyfin.service
     ```
 
     At this point the container will only start when the user logs in and shutdown when they log off. To have the container start as the user at first login we'll have to include one more option.
@@ -245,10 +251,10 @@ As always it is recommended to run the container rootless. Therefore we want to 
     loginctl enable-linger <username>
     ```
 
-5. Start the service.
+6. To enable Podman auto-updates, enable the necessary Systemd timer. 
 
     ```sh
-    systemctl --user start container-myjellyfin.service
+    systemctl --user enable --now podman-auto-update.timer
     ```
 
 ### Cloudron

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -140,9 +140,7 @@ A community project to deploy Jellyfin on Kubernetes-based platforms exists [at 
 
 ### Podman
 
-[Podman](https://podman.io) allows you to run containers as non-root. It's also the officially supported container solution on RHEL and CentOS.
-
-Steps to run Jellyfin using Podman are almost identical to Docker steps:
+[Podman](https://podman.io) allows you to run rootless containers. It's also the officially supported container solution on Fedora Linux and its derivatives such as CentOS Stream and RHEL. Steps to run Jellyfin using Podman are similar to the Docker steps.
 
 1. Install Podman:
 
@@ -173,7 +171,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     docker.io/jellyfin/jellyfin:latest
    ```
 
-Note that Podman doesn't require root access.
+Podman doesn't require root access to run containers.
 For security, the Jellyfin container should be run using rootless Podman.
 Furthermore, it is safer to run as a non-root user within the container.
 The `--user` option will run with the provided user id and group id *inside* the container.

--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -157,7 +157,7 @@ Steps to run Jellyfin using Podman are almost identical to Docker steps:
     --volume jellyfin-config:/config \
     --volume jellyfin-cache:/cache \
     --volume jellyfin-media:/media \
-    -p 8096:8096 \
+    --publish 8096:8096/tcp \
     --label "io.containers.autoupdate=registry" \
     --name myjellyfin \
     docker.io/jellyfin/jellyfin:latest


### PR DESCRIPTION
I recently was helping someone get their Jellyfin server up and running using Podman and figured I should update the existing documentation here.
The Podman example is pretty out-of-date.
This PR adds missing steps when running rootless Podman, updates the Podman run command, and uses better, more secure defaults such as running as non-root within the Jellyfin container.
Changes to the Podman run command should properly allow for automatic updates now, as well.