### PR TITLE
Give recommended way to get XMLTV data

### DIFF
--- a/general/server/live-tv/setup-guide.md
+++ b/general/server/live-tv/setup-guide.md
@@ -73,6 +73,8 @@ Schedules Direct is a paid service that provides U.S. and Canadian guide data fo
 
 This option allows for downloading of guide data in the [XMLTV](http://wiki.xmltv.org/index.php/XMLTVFormat) format.
 
+To create an XML file with guide data, there are several different methods. A reliable way to do this is to use [shuaiscott's zap2xml Docker container](https://github.com/shuaiscott/zap2xml).
+
 ## Mapping Channels
 
 Guide data from the 'TV Guide Data Providers' will need to be mapped to the physical channel from the tuner. Click the '...' next to the guide provider you set up and select 'Map Channels'


### PR DESCRIPTION
There is conflicting repos, scripts, etc and lots of outdated documentation on how to do this. By giving an example, users will be guided to a repo with a docker container that is easy to set up, run, and generates reputable guide data.