### PR TITLE
Add unmentioned video extra folders

### DIFF
--- a/general/server/media/movies.md
+++ b/general/server/media/movies.md
@@ -83,6 +83,7 @@ Supported folder types are:
 * `shorts`
 * `featurettes`
 * `extras` - Generic catch all for extras of an unknown type.
+* `trailers`
 
 ```txt
 Movies

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -95,3 +95,24 @@ Series (2010)/Season 01/episode filename-thumb.jpg *for the thumbnail of an epis
 Example:
 
 Series (2010)/logo.png
+
+## Other
+
+### Theme Videos
+
+* backdrops/*
+
+Example:
+
+Series (2010)/backdrops/S1Intro.ext
+
+### Theme Music
+
+* theme.ext
+* theme-music/*
+
+Examples:
+
+Series (2010)/theme.ext
+
+Series (2010)/theme-music/intro-song.ext


### PR DESCRIPTION
I split these between movies and shows because I haven't tested directory paths for backdrops and theme music in a movie.

Reviewer question: video extras don't target movies or shows specifically, should the extras section on both be extracted out to a new "Video Extras" page with sample paths for either included to avoid duplicating content trying to fully describe extra labeling in multiple places?

Relates to #619