### PR TITLE
Revert "fix: add /socket suffix to nginx rev proxy endpoint for websocket communication"

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -88,7 +88,7 @@ server {
 
     location /socket {
         # Proxy Jellyfin Websockets traffic
-        proxy_pass http://$jellyfin:8096/socket;
+        proxy_pass http://$jellyfin:8096;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Reverts jellyfin/jellyfin-docs#607.  This is incorrect and is causing issues for some users