### PR TITLE
Book metadata documentation and known limitations

### DIFF
--- a/general/server/media/books.md
+++ b/general/server/media/books.md
@@ -37,10 +37,10 @@ Either the `content.opf` or the `metadata.opf` file can tell Jellyfin which file
 
 ## Reader Support
 
-Jellyfin Web supports to save your reading progress. This functionality is, however, limited. For books of the type pdf, this is limited to chapters and sub-chapters only. Books stored in the epub format save the reading progress on a per-chapter basis.
+Jellyfin Web supports to save your reading progress. This functionality is, however, limited. Books stored in the epub format save the reading progress on a per-chapter basis as they do not have a concept of pages. Formats, like the comic book archive, save your progress per page.
 
 > [!Note]
-> Jellyfin saves your reading progress based on a time interval. This means, Jellyfin might not save your progress immediately when you enter a new chapter.
+> Jellyfin saves your epub reading progress based on a 10 seconds time interval.
 
 ## Primary
 

--- a/general/server/media/books.md
+++ b/general/server/media/books.md
@@ -35,13 +35,6 @@ In case the book is stored in the epub format, internal metadata can be provided
 
 Either the `content.opf` or the `metadata.opf` file can tell Jellyfin which file should be used for the books cover. Usually, this is the `cover.ext` file. The abbreviation `ext` stands for extension, e.g. `.png` or `.jpg`.
 
-## Reader Support
-
-Jellyfin Web supports to save your reading progress. This functionality is, however, limited. Books stored in the epub format save the reading progress on a per-chapter basis as they do not have a concept of pages. Formats, like the comic book archive, save your progress per page.
-
-> [!Note]
-> Jellyfin saves your epub reading progress based on a 10 seconds time interval.
-
 ## Primary
 
 * folder

--- a/general/server/media/books.md
+++ b/general/server/media/books.md
@@ -19,15 +19,34 @@ Books
 └── Books
     └── Author
         ├── Book1.epub
-        └── Book2.mp3
+        ├── Book2.epub
+        ├── Book
+        │   ├── Book1.epub
+        │   ├── cover.ext
+        │   └── metadata.opf
+        └── Book3.mp3
 ```
 
 File extensions supported include azw, azw3, cb7, cbr, cbt, cbz, epub, mobi, and pdf.
+
+## Local Metadata
+
+In case the book is stored in the epub format, internal metadata can be provided. For every other format, metadata has to be provided externally in a `content.opf` or `metadata.opf` file. When multiple books have been published by the same author, it is recommended to place each book into a seperate folder. This allows to provide local metadata for every book.
+
+Either the `content.opf` or the `metadata.opf` file can tell Jellyfin which file should be used for the books cover. Usually, this is the `cover.ext` file. The abbreviation `ext` stands for extension, e.g. `.png` or `.jpg`.
+
+## Reader Support
+
+Jellyfin Web supports to save your reading progress. This functionality is, however, limited. For books of the type pdf, this is limited to chapters and sub-chapters only. Books stored in the epub format save the reading progress on a per-chapter basis.
+
+> [!Note]
+> Jellyfin saves your reading progress based on a time interval. This means, Jellyfin might not save your progress immediately when you enter a new chapter.
 
 ## Primary
 
 * folder
 * poster
+* cover
 
 ## Banner
 

--- a/general/server/media/comics.md
+++ b/general/server/media/comics.md
@@ -7,6 +7,11 @@ title: Comics
 
 Comics and mangas, from now on referred to as comics, should usually be in the library root directory or in a subfolder for the individual comics. The subfolders allow for organization of metadata and images.
 
+> [!Note]
+> For the best reading experience, it is recommended to store comics in the comic book archive or pdf format. This is due to issues when trying to read comics stored in the epub format. Please note, that Jellyfin saves your reading position for comics in the comic book archive format, but does not save whether you finished the comic or not.
+
+## Naming
+
 For best results, it is recommended to name the files similar to the following schema where the volume number and issue number are used **interchangeable**.
 
 ```txt
@@ -17,7 +22,7 @@ Series_Name (SeriesYear) #IssueNum (of Count) (PubYear).ext
 - Count = Total number of issues
 - PubYear = Publication year of the issue
 - SeriesYear = Start year of the series
-- .ext = file extension, e.g. `.cbz` or `.cbr`
+- .ext = file extension, e.g. `.cbz` or `.cbr`. For a list of supported file extension, please refer to the [section on books](xref:server-media-books).
 
 Take a look at the following example:
 

--- a/general/server/media/comics.md
+++ b/general/server/media/comics.md
@@ -22,7 +22,7 @@ Series_Name (SeriesYear) #IssueNum (of Count) (PubYear).ext
 - Count = Total number of issues
 - PubYear = Publication year of the issue
 - SeriesYear = Start year of the series
-- .ext = file extension, e.g. `.cbz` or `.cbr`. For a list of supported file extension, please refer to the [section on books](xref:server-media-books).
+- .ext = file extension, e.g. `.cbz` or `.cbr`. For a list of supported file extensions, please refer to the [section on books](xref:server-media-books).
 
 Take a look at the following example:
 


### PR DESCRIPTION
This pull-request documents the metadata support for books.

It also documents known limitations of the reader support for Jellyfin Web. These limitations are based on personal tests in Jellyfin 10.8. There are probably a few more limitations that I'm not aware of which could be documented by someone who is aware of them in a future PR.