### PR TITLE
Update hardware acceleration docs for 10.8

### DIFF
--- a/general/administration/hardware-acceleration.md
+++ b/general/administration/hardware-acceleration.md
@@ -5,9 +5,11 @@ title: Hardware Acceleration
 
 # Hardware Acceleration
 
-Jellyfin supports [hardware acceleration (HWA) of video encoding/decoding using FFMpeg](https://trac.ffmpeg.org/wiki/HWAccelIntro). FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through Video Acceleration API's.
+Jellyfin supports [hardware acceleration (HWA) of video encoding/decoding using FFMpeg](https://trac.ffmpeg.org/wiki/HWAccelIntro).
+FFMpeg and Jellyfin can support multiple hardware acceleration implementations such as Intel Quicksync (QSV), AMD AMF, nVidia NVENC/NVDEC, OpenMax OMX and MediaCodec through Video Acceleration API's.
 
-[VA-API](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a Video Acceleration API that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA. [QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VA-API and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md) and their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
+[VA-API](https://en.wikipedia.org/wiki/Video_Acceleration_API) is a Video Acceleration API that uses [libva](https://github.com/intel/libva/blob/master/README.md) to interface with local drivers to provide HWA.
+[QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) uses a modified (forked) version of VA-API and interfaces it with [libmfx](https://github.com/intel/media-driver/blob/master/README.md) and their proprietary drivers [(list of supported processors for QSV)](https://ark.intel.com/content/www/us/en/ark.html#@Processors).
 
 OS      | Recommended HW Acceleration
 ------- | -------------
@@ -30,7 +32,8 @@ RPi    | V4L2, OMX (deprecated)
 
 ## Enabling Hardware Acceleration
 
-Hardware acceleration options can be found in the Admin Dashboard under the **Transcoding** section of the **Playback** tab. Select a valid hardware acceleration option from the drop-down menu, indicate a device if applicable, and check `Enable hardware encoding` to enable encoding as well as decoding, if your hardware supports this.
+Hardware acceleration options can be found in the Admin Dashboard under the **Transcoding** section of the **Playback** tab.
+Select a valid hardware acceleration option from the drop-down menu, indicate a device if applicable, and check `Enable hardware encoding` to enable encoding as well as decoding, if your hardware supports this.
 
 The hardware acceleration is available immediately for media playback. No server restart is required.
 
@@ -46,81 +49,123 @@ or using `lshw`:
 lshw -C display
 ```
 
-## Tips on H.264 / AVC 10-bit videos
+## H.264 / AVC 10-bit videos
 
 The hardware decoding of H.264 10-bit aka High10 profile video is not supported by any Intel, AMD or NVIDIA GPU.
 
 Please consider upgrading these videos to HEVC 10-bit aka Main10 profile if you want to offload your CPU usage during transcoding.
 
-## Tips for Intel Gen9 and Gen11+ when using VAAPI or QSV on Linux
+## Intel Gen9 and Gen11+ iGPUs
 
-The Intel [Guc/Huc firmware](https://01.org/linuxgraphics/downloads/firmware) must be enabled for optional Low-Power encoding (pre-Gen11 only supports LP H.264).
+> [!NOTE]
+> The Intel [Guc/Huc firmware](https://01.org/linuxgraphics/downloads/firmware) must be enabled for optional Low-Power encoding (pre-Gen11 only supports Low-Power H.264).
 
-Instructions for ArchLinux: [Arch Wiki](https://wiki.archlinux.org/title/intel_graphics#Enable_GuC_/_HuC_firmware_loading) and for Debian/Ubuntu: [Brainiarc7's gist](https://gist.github.com/Brainiarc7/aa43570f512906e882ad6cdd835efe57)
+Instructions:
 
-For Jasper Lake chips (such as N5095 and N6005), Low-Power encoding must be enabled. But the linux-firmware support is not ready in Ubuntu 20.04.3 LTS. The 21.10 or newer distro is required.
+- ArchLinux: [Arch Wiki](https://wiki.archlinux.org/title/intel_graphics#Enable_GuC_/_HuC_firmware_loading)
+- Debian/Ubuntu: [Brainiarc7's gist](https://gist.github.com/Brainiarc7/aa43570f512906e882ad6cdd835efe57)
+
+> [!WARNING]
+> For Jasper Lake chips (such as N5095 and N6005), Low-Power encoding must be enabled.
+> The linux-firmware support is not included in Ubuntu 20.04.3 LTS. Any Ubuntu from 21.10 does include the required drivers.
 
 ## Supported Acceleration Methods
 
-In Jellyfin 10.8, full hardware-accelerated filtering (scaling, deinterlacing, tone mapping and subtitle burn-in) on Intel, AMD and NVIDIA hardware have been verified with `jellyfin-ffmpeg` 4.4.1.
-
-**Using the old or original version of FFmpeg binary may disable some hardware filtering improvements.**
+> [!Important]
+> In Jellyfin 10.8 full hardware-accelerated filtering (scaling, deinterlacing, tone mapping and subtitle burn-in) on Intel, AMD and NVIDIA hardware are available.
+>
+> **`jellyfin-ffmpeg` version 4.4.1-2 or higher is required, using an older or original version of FFmpeg may disable some hardware filtering improvements.**
 
 ### NVIDIA NVENC
 
-**The minimum required driver version is: Linux: 455.28, Windows: 456.71 since Jellyfin 10.8 release.**
+> [!NOTE]
+> **Minimum required driver version since Jellyfin 10.8:**
+>
+> - **Linux:** 455.28
+> - **Windows:** 456.71
 
-[NVIDIA using ffmpeg official list](https://developer.nvidia.com/ffmpeg). Not every card has been tested. These [drivers](https://github.com/keylase/nvidia-patch) are recommended for Linux and Windows. Here is the official list of [NVIDIA Graphics Cards](https://developer.nvidia.com/video-encode-decode-gpu-support-matrix) for supported codecs. Example of Ubuntu working with [NVENC](https://www.reddit.com/r/jellyfin/comments/amuyba/nvenc_nvdec_working_in_jellyfin_on_ubuntu_server/).
+Not every card has been tested.
+
+If you want more than three parallel transcoding streams on a consumer (non-Quadro) NVIDIA card, you can use [this patch](https://github.com/keylase/nvidia-patch) to remove the limit.
+The patch is recommended for Linux and Windows but may break in the future, so check the compatible driver versions before applying it.
 
 On Linux use `nvidia-smi` to check driver and GPU card version.
 
+**Useful links:**
+
+- [Official list of supported codecs for recent NVIDIA Graphics Cards](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
+- [Official NVIDIA ffmpeg development docs](https://developer.nvidia.com/ffmpeg).
+
 ### VA-API
 
-List of supported codecs for [VA-API](https://wiki.archlinux.org/index.php/Hardware_video_acceleration#Comparison_tables). Intel iGPU, AMD GPU.
-
 > [!NOTE]
-> AMD GPU requires open source driver Mesa 20.1 or higher to support hardware decoding HEVC.
+> Intel iGPU and AMD GPU only.
 
-> [!NOTE]
-> As of 10.7.1, the Docker image uses Debian 10 and thus Mesa 18.3.6. To upgrade it, you'll need to make your own image based on a more recent distribution.
+A List of supported codecs for VA-API can be found [on the Archlinux wiki](<https://wiki.archlinux.org/index.php/Hardware_video_acceleration#Comparison_tables>).
+
+> [!WARNING]
+> As of **Jellyfin 10.8** the official Docker image uses Debian 11 which has a compatible version of Mesa for **AMD GPU HEVC** decoding.
+>
+> Earlier images do not provide a compatible version of Mesa.
 
 ### AMD AMF
 
-**Full OpenCL based hardware filtering in AMF is supported on Windows 10 or newer since Jellyfin 10.8 release.**
-
-AMF is available on Windows and Linux.
-
-However AMD has not implemented the Vulkan based HW decoder and scaler in ffmpeg, the decoding speed may not be as expected on Linux. The closed source driver `amdgpu-pro` is required when using AMF on Linux.
-
 > [!NOTE]
-> Most Zen CPUs do not come with integrated graphics. You will need a dedicated GPU (dGPU) or a Zen CPU with integrated graphics for hardware acceleration. If your Zen CPU is suffixed with a "G" or "GE" in model name, you have integrated graphics.
+> AMF is available on Windows and Linux.
+
+> [!WARNING]
+> As of **Jellyfin 10.8** full OpenCL based hardware filtering in AMF is supported on Windows 10 and newer.
+>
+> AMD has not implemented the Vulkan based HW decoder and scaler in ffmpeg, the decoding speed may not be as expected on Linux.
+>
+> The closed source driver `amdgpu-pro` is required when using AMF on Linux.
+
+> [!TIP]
+> Most Zen CPUs **do not** come with integrated graphics. You will need a **dedicated GPU** (dGPU) or a Zen CPU with integrated graphics for hardware acceleration.
+> If your Zen CPU is suffixed with a *G* or *GE* in model name, you have integrated graphics.
 
 ### Intel QuickSync
 
-Intel QSV Benchmarks on [Linux](https://www.intel.com/content/www/us/en/architecture-and-technology/quick-sync-video/quick-sync-video-installation.html).
+> [!NOTE]
+> Intel QuickSync (QSV) is available on Linux and as a hybrid solution of DXVA2/D3D11VA for decoding and the libmfx library for encoding on Windows.
 
-On Windows, you can use the DXVA2/D3D11VA libraries for decoding and the libmfx library for encoding.
+> [!IMPORTANT]
+> To use QSV on Windows, please do **not** install Jellyfin as a **system service**.
+
+> [!IMPORTANT]
+> To use QSV on Linux with recent Intel iGPUs the **nonfree [Intel media driver](https://github.com/intel/media-driver)** is required for full hardware acceleration.
+> If you are using `jellyfin-ffmpeg` version 4.4.1-2 or higher it is included and you do not need to install it seperatly.
+
+**Known Issues:**
+
+- [Intel QSV Benchmarks on Linux](https://www.intel.com/content/www/us/en/architecture-and-technology/quick-sync-video/quick-sync-video-installation.html)
+- [FFmpeg Windows version with QSV hwaccel fails over TERMINAL](https://trac.ffmpeg.org/ticket/7511)
+- [Intel QSV: "Failed to create Direct3D device" on Core i7-7700K (Skylake) on Windows 10](https://trac.ffmpeg.org/ticket/6827)
+- [Collection of useful links and information](https://github.com/Artiume/jellyfin-docs/blob/master/general/wiki/main.md)
+
+----
+
+> [!TIP]
+> If your Jellyfin server does not support hardware acceleration, but you have another machine that does, you can leverage [rffmpeg](https://github.com/joshuaboniface/rffmpeg) to delegate the transcoding to another machine.
+> Currently Linux-only and requires SSH between the machines, as well as shared storage both for media and for the Jellyfin data directory.
+
+## Common setups
+
+Each hardware acceleration type, as well as each Jellyfin installation type, has different prerequisites for enabling hardware acceleration.
+It is always best to consult [the FFMpeg documentation]((https://trac.ffmpeg.org/wiki/HWAccelIntro)) on the acceleration type you choose for the latest information.
+
+### Hardware acceleration on Docker (Linux)
 
 > [!NOTE]
-> To use QSV on Windows, please do not install Jellyfin as a system service.
+> This are general instructions, for more specific instructions pleas check the next sections!
 
-Issues: [FFmpeg Windows version with QSV hwaccel fails over TERMINAL](https://trac.ffmpeg.org/ticket/7511) and [Intel QSV: "Failed to create Direct3D device" on Core i7-7700K (Skylake) on Windows 10](https://trac.ffmpeg.org/ticket/6827)
+In order to use hardware acceleration in Docker, the devices must be passed to the container.
+To see what video devices are available, you can run `sudo lshw -c video` or `vainfo` on your machine.
+VA-API may require the `render` group added to the docker permissions.
+The `render` group id can be discovered in `/etc/group` such as `render:x:122:`.
 
-CentOS may require [additional drivers](https://www.getpagespeed.com/server-setup/how-to-enable-intel-hardware-acceleration-for-video-playback-in-rhel-centos-8) for QSV.
-
-Here's [additional information](https://github.com/Artiume/jellyfin-docs/blob/master/general/wiki/main.md) to learn more.
-
-If your Jellyfin server does not support hardware acceleration, but you have another machine that does, you can leverage [rffmpeg](https://github.com/joshuaboniface/rffmpeg) to delegate the transcoding to another machine. Currently Linux-only and requires SSH between the machines, as well as shared storage both for media and for the Jellyfin data directory.
-
-## Common setup
-
-Each hardware acceleration type, as well as each Jellyfin installation type, requires different setup options before it can be used. It is always best to consult [the FFMpeg documentation]((https://trac.ffmpeg.org/wiki/HWAccelIntro)) on the acceleration type you choose for the latest information.
-
-### Acceleration on Docker
-
-In order to use hardware acceleration in Docker, the devices must be passed to the container. To see what video devices are available, you can run `sudo lshw -c video` or `vainfo` on your machine. VA-API may require the `render` group added to the docker permissions. The `render` group id can be discovered in /etc/group such as `render:x:122:`.
-
-You can use `docker run` to start the server with a command like the one below.
+You can use `docker run` to start the server with the required permissions and devices.
+An example command is shown below.
 
 ```sh
 docker run -d \
@@ -152,33 +197,28 @@ services:
       - /path/to/cache:/cache
       - /path/to/media:/media
     devices:
-      # VAAPI Devices
+      # VAAPI Devices (examples)
       - /dev/dri/renderD128:/dev/dri/renderD128
       - /dev/dri/card0:/dev/dri/card0
-      # RPi 4
-      - /dev/vchiq:/dev/vchiq
 ```
 
-### Linux Docker NVIDIA NVENC
+### NVIDIA hardware acceleration on Docker (Linux)
 
 In order to achieve hardware acceleration using Docker, several steps are required.
 
 Prerequisites:
 
-[NVIDIA Container Toolkit installation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#getting-started)
-
 - GNU/Linux x86_64 with kernel version > 3.10
 - Docker >= 19.03
 - NVIDIA GPU with Architecture > Fermi (2.1)
 - NVIDIA drivers >= 361.93
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#getting-started) needs to be installed
 
 Follow the instructions in the link above to install the NVIDIA Container Toolkit for your Linux distribution.
 
-Start your container adding these parameters:
+Start your container by adding this parameter:
 
 ```sh
--e NVIDIA_DRIVER_CAPABILITIES=all \
--e NVIDIA_VISIBLE_DEVICES=all \
 --gpus all \
 ```
 
@@ -187,8 +227,6 @@ A complete run command would look like this:
 ```sh
 docker run -d \
  --name=jellyfin \
- -e NVIDIA_DRIVER_CAPABILITIES=all \
- -e NVIDIA_VISIBLE_DEVICES=all \
  --gpus all \
  -p 8096:8096 \
  -p 8920:8920 \
@@ -199,16 +237,13 @@ docker run -d \
  jellyfin/jellyfin
 ```
 
-Or with docker-compose >1.28, add the `deploy` and `environment` parts to your Jellyfin service:
+Or with docker-compose >1.28, add the `deploy` section to your Jellyfin service:
 
 ```yaml
 services:
   jellyfin:
     image: jellyfin/jellyfin
   # ... your Jellyfin config
-  environment:
-    NVIDIA_DRIVER_CAPABILITIES: all
-    NVIDIA_VISIBLE_DEVICES: all
   deploy:
     resources:
       reservations:
@@ -225,7 +260,7 @@ There are some special steps when running with the following option:
 You may need to add this user to the video group on your host machine:
 
 ```sh
-usermod -aG video user
+usermod -aG video <user>
 ```
 
 Once the container is started you can again validate access to the host resources:
@@ -242,62 +277,16 @@ docker exec -it jellyfin ldconfig
 
 After that, you should ensure the NVIDIA driver loads correctly.
 
-### Configuring OpenCL / CUDA / Intel VPP Tone-Mapping
-
-Hardware based tone-mapping with NVIDIA NVENC, AMD AMF, Intel QSV and VA-API is through OpenCL or CUDA.
-
-Intel hardware based VPP tone-mapping is supported on Intel QSV and VA-API on Linux. VPP is prefered when both two tone-mapping options are checked on Intel.
-
-OS/Platform | NVIDIA NVENC | AMD AMF  | Intel QSV | Intel VA-API | AMD VA-API | Software
------------ | ------------ | -------- | ----------- | --------- | --------- | --------
-Linux       | ✔️          | ✔️       | ✔️        | ✔️          | ✔️   | WIP
-Windows     | ✔️           | ✔️       | ✔️        | N/A         | N/A       | WIP
-Docker      | ✔️           | untested | ✔️        | ✔️          | untested   | WIP
-
 > [!NOTE]
-> Tone-mapping on Windows with Intel QSV and AMD AMF requires Windows 10 or newer.
+> The official Jellyfin Docker image already sets the required environment variables to allow access to the GPUs via the NVIDIA container runtime.
+> If you are building your own image don't forget to include `NVIDIA_DRIVER_CAPABILITIES=all` and  `NVIDIA_VISIBLE_DEVICES=all` into your container's environment.
 
-> [!NOTE]
-> Make sure the hardware acceleration is well configured before reading this section.
-
-1. On Windows: Install the latest NVIDIA or AMD or Intel drivers.
-
-2. On Linux or docker:
-   - For AMD cards, install `amdgpu-pro` with opencl arguments. See **Configuring AMD AMF encoding on Ubuntu 18.04 or 20.04 LTS** for more details.
-
-    ```sh
-    sudo ./amdgpu-pro-install -y --opencl=pal,legacy
-    sudo usermod -aG video $LOGNAME
-    sudo usermod -aG render $LOGNAME
-    ```
-
-   - For Intel iGPUs, you have two types of tone-mapping methods: OpenCL and VPP. Choose the latter one for faster transcoding speed, but fine tuning options are not supported.
-
-    Method OpenCL: Follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases). If you are using the docker image from jellyfin/jellyfin or linuxserver/jellyfin, this step can be skipped.
-
-    Method VPP: Install `intel-media-va-driver-non-free` 20.1 and `jellyfin-ffmpeg` 4.4.1-1 or newer.
-
-   > [!NOTE]
-   > Tone mapping on Intel VA-API and QSV needs an iGPU that supports 10-bit decoding, such as i3-7100 and J4105.
-   > Do not use the `intel-opencl-icd` package from the repository since they were not build with RELEASE_WITH_REGKEYS enabled for P010 pixel interop flags.
-
-3. Debugging: Check the OpenCL device status. You will see corresponding vendor name if it goes well.
-
-   - Use `clinfo`: Install `clinfo` before using it. `sudo apt update && sudo apt install clinfo -y` on Debian/Ubuntu or `sudo pacman -Sy clinfo` on Arch. Then `sudo clinfo`
-
-   - Use `jellyfin-ffmpeg`: `/usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl`
-
-### Configuring VA-API acceleration on Debian/Ubuntu
+### VA-API hardware acceleration on Debian/Ubuntu
 
 Configuring VA-API on Debian/Ubuntu requires some additional configuration to ensure permissions are correct.
 
-To check information about VA-API on your system install and run `vainfo` from the command line.
-
-   > [!NOTE]
-   > For Intel Comet Lake or newer iGPUs, the legacy i965 VA-API driver is incompatible with your hardware.
-   > Please follow the instructions from **Configuring Intel QuickSync(QSV) on Debian/Ubuntu** to get the newer iHD driver.
-
-1. Configure VA-API for your system by following the [relevant documentation](https://wiki.archlinux.org/index.php/Hardware_video_acceleration). Verify that a `render` device is now present in `/dev/dri`, and note the permissions and group available to write to it, in this case `render`:
+1. Configure VA-API for your system by following the documentation of your OS and/or vendor.
+   Verify that a `render` device is now present in `/dev/dri`, and note the permissions and group available to write to it, in this case `render`:
 
     ```sh
     $ ls -l /dev/dri
@@ -309,53 +298,44 @@ To check information about VA-API on your system install and run `vainfo` from t
     ```
 
     > [!NOTE]
-    > On some releases, the group may be `video` instead of `render`.
+    > On some releases, the group may be `video` or `input` instead of `render`.
 
-2. Add the Jellyfin service user to the above group to allow Jellyfin's FFMpeg process access to the device, and restart Jellyfin.
+2. Make sure that `jellyfin-ffmpeg` version 4.4.1-2 or higher is installed.
+
+3. Check the output of `/usr/lib/jellyfin-ffmpeg/vainfo`.
+
+4. Add the Jellyfin service user to the above group to allow Jellyfin's FFMpeg process access to the device, and restart Jellyfin.
 
     ```sh
     sudo usermod -aG render jellyfin
     sudo systemctl restart jellyfin
     ```
 
-3. Configure VA-API acceleration in the "Transcoding" page of the Admin Dashboard. Enter the `/dev/dri/renderD128` device above as the `VA API Device` value.
+5. Configure VA-API acceleration in the `Transcoding` page of the Admin Dashboard.
+   Enter the `/dev/dri/renderD128` device above as the `VA API Device` value.
 
-4. Watch a movie, and verify that transcoding is occurring by watching the `ffmpeg-transcode-*.txt` logs under `/var/log/jellyfin` and using `radeontop` or similar tools.
+6. Watch a movie, and verify that transcoding is occurring by watching the `ffmpeg-transcode-*.txt` logs under `/var/log/jellyfin` and using `radeontop` (AMD only) or similar tools.
 
-### Configuring Intel QuickSync(QSV) on Debian/Ubuntu
+### Intel QuickSync (QSV) hardware acceleration on Debian/Ubuntu
 
 1. QSV is based on VA-API device on Linux, so please confirm whether you have completed the VA-API configuration first.
 
-2. Make sure that `jellyfin-ffmpeg 4.3.1-1` or higher is installed.
+2. Make sure that `jellyfin-ffmpeg` version 4.4.1-2 or higher is installed (it ships the current version of `intel-media-driver (iHD)` which is required for QSV).
 
-3. Install the non-free iHD driver.
+3. Verify that the iHD driver is properly loaded and recognizes your iGPU.
 
-   ```bash
-   sudo apt update
-   sudo apt install vainfo intel-media-va-driver-non-free -y
-   ```
+    ```sh
+    sudo /usr/lib/jellyfin-ffmpeg/vainfo | grep iHD
+    ```
 
-   > [!NOTE]
-   > For Intel Comet Lake or newer iGPUs, make sure the version of `intel-media-va-driver-non-free` >= 19.1.
-   > `intel-media-va-driver-non-free` is avaliable from apt since Debian buster and Ubuntu 19.04. Otherwise you have to build from source.
+4. Configure QSV acceleration in the `Transcoding` page of the Admin Dashboard.
 
-4. Verify iHD driver using `vainfo`. You will find `iHD` from the result if it goes well.
+5. Watch a movie, and verify that transcoding is occurring by watching the `ffmpeg-transcode-*.txt` logs under `/var/log/jellyfin` and using `intel_gpu_top` (can be installed with the `intel-gpu-tools` package).
 
-   ```bash
-   vainfo | grep iHD
-   ```
+### VA-API and QSV hardware acceleration on LXC or LXD container
 
-5. If you want to uninstall iHD driver and fallback to i965 driver.
-
-   ```bash
-   sudo apt remove intel-media-va-driver intel-media-va-driver-non-free -y
-   ```
-
-6. QSV in docker. Due to incompatible licenses, we will not integrate non-free drivers in the docker image. You need to perform the above operations manually in docker and add `--privileged` to the docker configuration.
-
-### LXC or LXD Container (Intel iGPU)
-
-This has been tested with LXC 3.0 and may or may not work with older versions.
+> [!WARNING]
+> This has been tested with LXC 3.0 and may or may not work with older versions.
 
 Follow the steps above to add the jellyfin user to the `video` or `render` group, depending on your circumstances.
 
@@ -392,19 +372,18 @@ Useful resources:
 - [LXD Documentation - GPU instance configuration](https://github.com/lxc/lxd/blob/master/doc/instances.md#type-gpu)
 - [NVidia CUDA inside a LXD container](https://stgraber.org/2017/03/21/cuda-in-lxd/)
 
-### LXC Container on Proxmox
+### VA-API and QSV hardware acceleration on LXC on Proxmox
 
-This has been tested on Proxmox VE 7.1 - on previous versions you may need to change `cgroup2` to `cgroup`.
-
-It is highly recommended to use the same OS as your Proxmox host as the container OS to prevent driver version missmatches.
-
-Jellyfin needs to run in a **privileged** container.
-
-You can convert an existing unprivileged container to a privileged container by taking a backup and restoring it as priviledged,
+> [!IMPORTANT]
+> Jellyfin needs to run in a **privileged** LXC container.
+> You can convert an existing unprivileged container to a privileged container by taking a backup and restoring it as priviledged.
 
 1. Install the required drivers on the Proxmox host
 
 2. Add your GPU to the container by editing `/etc/pve/lxc/<container-id>.conf` (you may need to change the GIDs in the examples below to match those used on you host).
+
+   > [!WARNING]
+   > This has been tested on `Proxmox VE 7.1` - on previous versions you may need to change `cgroup2` to `cgroup`.
 
    Intel iGPU:
 
@@ -443,9 +422,9 @@ You can convert an existing unprivileged container to a privileged container by 
 
 8. You can also try playing a video that requires transcoding, and if it plays you're good.
 
-### Configuring AMD AMF encoding on Ubuntu 18.04 or 20.04 LTS
+### AMD AMF encoding on Ubuntu 18.04 or 20.04 LTS
 
-1. Install `amdgpu-pro` closed source graphics driver by following the [installation instructions](https://amdgpu-install.readthedocs.io/en/latest/).
+1. Install the `amdgpu-pro` closed source graphics driver by following the [installation instructions](https://amdgpu-install.readthedocs.io/en/latest/).
 
 2. Then install `amf-amdgpu-pro`.
 
@@ -453,7 +432,7 @@ You can convert an existing unprivileged container to a privileged container by 
    sudo apt install amf-amdgpu-pro
    ```
 
-3. Make sure your `jellyfin-ffmpeg` or `ffmpeg` contains `h264_amf` encoder.
+3. Check if `jellyfin-ffmpeg` contains `h264_amf` encoder:
 
    ```bash
    $ cd /usr/lib/jellyfin-ffmpeg/
@@ -462,15 +441,13 @@ You can convert an existing unprivileged container to a privileged container by 
    ```
 
    > [!NOTE]
-   > If not contain, update your `jellyfin-ffmpeg` to the latest version and try again.
-
-   For compiling ffmpeg with AMF library, refer to [this page](https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE).
+   > If not available, update your `jellyfin-ffmpeg` to the latest version and try again.
 
 4. Choose AMD AMF video acceleration in Jellyfin and check the `Enable hardware encoding` option.
 
 5. Watch a movie, then verify that `h264_amf` encoder is working by watching the `ffmpeg-transcode-*.txt` transcoding logs under `/var/log/jellyfin` and using `radeontop` or similar tools.
 
-### Configuring AMD AMF encoding on Arch Linux
+### AMD AMF encoding on Arch Linux
 
 AMD does not provide official `amdgpu-pro` driver support for Arch Linux, but fortunately, a third-party packaged `amdgpu-pro-installer` is provided in the archlinux user repository.
 
@@ -487,9 +464,12 @@ AMD does not provide official `amdgpu-pro` driver support for Arch Linux, but fo
    makepkg -si
    ```
 
-3. Go to step 3 of **on Ubuntu 18.04 or 20.04 LTS** above.
+3. Go to step 3 of [Configuring AMD AMF encoding on Ubuntu 18.04 or 20.04 LTS](xref:admin-hardware-acceleration#amd-amf-encoding-on-ubuntu-1804-or-2004-lts) above.
 
-### Raspberry Pi 3 and 4
+### OpenMAX OMX encoding on Raspberry Pi 3 and 4
+
+> [!WARNING]
+> Since Jellyfin 10.8 hardware acceleration on Raspbetty Pi via OpenMAX OMX is deprecated and not further worked on because Raspberry Pi currently migrates to a `V4L2` based hardware acceleration.
 
 1. Add the Jellyfin service user to the video group to allow Jellyfin's FFMpeg process access to the encoder, and restart Jellyfin.
 
@@ -527,37 +507,94 @@ AMD does not provide official `amdgpu-pro` driver support for Arch Linux, but fo
     vcgencmd measure_temp && vcgencmd measure_clock arm
     ```
 
-> [!NOTE]
-> RPi4 currently doesn't support HWA HEVC decoding, only encode and decode H.264. [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for transcoding. Only Raspbian OS works so far. For docker, only the linuxserver image works. For more tips see [here](https://www.reddit.com/r/jellyfin/comments/ei6ew6/rpi4_hardware_acceleration_guide/).
+> [!WARNING]
+> RPi4 currently doesn't support HWA HEVC decoding, only encoding and decoding H.264 is supported.
+> [Active cooling](https://www.jeffgeerling.com/blog/2019/raspberry-pi-4-needs-fan-heres-why-and-how-you-can-add-one) is required, passive cooling is insufficient for transcoding.
+> HWA only works on Raspbian OS. For docker, only the linuxserver image works.
+>
+> For more tips see [here](https://www.reddit.com/r/jellyfin/comments/ei6ew6/rpi4_hardware_acceleration_guide/).
 
-> [!NOTE]
+> [!IMPORTANT]
 > As per [this issue](https://github.com/jellyfin/jellyfin/issues/4023), hardware acceleration is not yet supported on 64-bit Raspberry Pi OS (and likely on derivative builds e.g. DietPi), as some libraries in the 32-bit build are still missing from the 64-bit build.
 
+### OpenCL / CUDA / Intel VPP Tone-Mapping
+
+Hardware based tone-mapping with NVIDIA NVENC, AMD AMF, Intel QSV and VA-API is done through OpenCL or CUDA.
+
+Intel hardware based VPP tone-mapping is supported on Intel QSV and VA-API on Linux.
+VPP is prefered when both two tone-mapping options are checked on Intel.
+
+OS/Platform | NVIDIA NVENC | AMD AMF  | Intel QSV   | Intel VA-API | AMD VA-API | Software
+----------- | ------------ | -------- | ----------- | ------------ | ---------- | --------
+Linux       | ✔️           | ✔️      | ✔️          | ✔️          | ✔️         | WIP
+Windows     | ✔️           | ✔️      | ✔️          | N/A          | N/A        | WIP
+Docker      | ✔️           | untested | ✔️         | ✔️           | untested   | WIP
+
 > [!NOTE]
-> For RPi3 in testing, transcoding was not working fast enough to run in real time because the video was being resized.
+> Tone-mapping on Windows with Intel QSV and AMD AMF requires Windows 10 or newer.
+
+> [!IMPORTANT]
+> Make sure the hardware acceleration is well configured before configuring tone-mapping with this instructions.
+
+1. **On Windows:** Install the latest NVIDIA, AMD or Intel drivers.
+
+2. **On Linux or Docker:**
+   - For **NVIDIA cards** no further configuration is necessary.
+   - For **AMD cards**, install `amdgpu-pro` with opencl arguments (see [Configuring AMD AMF encoding on Ubuntu 18.04 or 20.04 LTS](xref:admin-hardware-acceleration#amd-amf-encoding-on-ubuntu-1804-or-2004-lts) for more details):
+
+    ```sh
+    sudo ./amdgpu-pro-install -y --opencl=pal,legacy
+    sudo usermod -aG video $LOGNAME
+    sudo usermod -aG render $LOGNAME
+    ```
+
+   - For **Intel iGPUs**, you have two types of tone-mapping methods: OpenCL and VPP. The latter one does not support fine tuning options.
+
+    **OpenCL:** Follow the instructions from [intel-compute-runtime](https://github.com/intel/compute-runtime/releases).
+    If you are using the official Docker image or the one from linuxserver this step can be skipped.
+
+    **VPP:** Make sure `jellyfin-ffmpeg` 4.4.1-2 or higher is installed.
+    Previous versions did not ship `intel-media-driver` thus it was required to be installed manually.
+
+   > [!WARNING]
+   > Tone mapping on Intel VA-API and QSV **requires an iGPU that supports 10-bit decoding**, such as i3-7100 or J4105.
+
+   > [!IMPORTANT]
+   > Do **not use** the `intel-opencl-icd` package from your distro's repository since they were not built with `RELEASE_WITH_REGKEYS` enabled, which is required for P010 pixel interop flags.
+
+3. **Debugging:** Check the OpenCL device status. You will see corresponding vendor name if it goes well.
+
+   - Use `clinfo`: Install `clinfo` before using it. `sudo apt install -y clinfo` on Debian/Ubuntu or `sudo pacman -Sy clinfo` on Arch. Then `sudo clinfo`.
+
+   - Use `jellyfin-ffmpeg`: `/usr/lib/jellyfin-ffmpeg/ffmpeg -v debug -init_hw_device opencl`
 
 ## Verifying Transcodes
 
-To verify that you are using the proper libraries, run this command against your transcoding log. This can be found at Admin Dashboard > Logs, and /var/log/jellyfin if instead via the repository.
+To verify that you are using the proper libraries, run this command against your transcoding log.
+This can be found at `Admin Dashboard > Logs`, and `/var/log/jellyfin` if installed via the apt repository.
 
 ```sh
-grep -A2 'Stream mapping:' /var/log/jellyfin/ffmpeg-transcode-85a68972-7129-474c-9c5d-2d9949021b44.txt
+grep -A2 'Stream mapping:' /var/log/jellyfin/ffmpeg-transcode-<random-id>>.log
 ```
 
 This returned the following results.
 
 ```data
+...
 Stream mapping:
 Stream #0:0 -> #0:0 (hevc (native) -> h264 (h264_omx))
 Stream #0:1 -> #0:1 (aac (native) -> mp3 (libmp3lame))
+...
 ```
 
 `Stream #0:0` used software (VAAPI Decode can also say native) to decode HEVC and used HWA to encode.
 
 ```data
+...
 Stream mapping:
 Stream #0:0 -> #0:0 (h264 (h264_mmal) -> h264 (h264_omx))
 Stream #0:1 -> #0:1 (flac (native) -> mp3 (libmp3lame))
+...
 ```
 
-`Stream #0:0` used HWA for both. h264_mmal to decode and h264_omx to encode.
+`Stream #0:0` used HWA for both. `h264_mmal` to decode and `h264_omx` to encode.


### PR DESCRIPTION
Refactor and update the hardware acceleration docs for the changes in 10.8 and jellyfin-ffmpeh 4.4.1-2.