### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload Artifacts To Github Pages
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:
-          github_token: ${{ secrets.JF_BOT_TOKEN }}
+          deploy_key: ${{ secrets.JF_BOT_TOKEN }}
           external_repository: jellyfin/jellyfin.github.io
           publish_branch: master
           publish_dir: ./


### PR DESCRIPTION
Deploying to an external repo requires `deploy_key`.