### PR TITLE
comic page to toc & information about required versions

### DIFF
--- a/general/server/media/comics.md
+++ b/general/server/media/comics.md
@@ -8,7 +8,7 @@ title: Comics
 Comics and mangas, from now on referred to as comics, should usually be in the library root directory or in a subfolder for the individual comics. The subfolders allow for organization of metadata and images.
 
 > [!Note]
-> For the best reading experience, it is recommended to store comics in the comic book archive or pdf format. This is due to issues when trying to read comics stored in the epub format. Please note, that Jellyfin saves your reading position for comics in the comic book archive format, but does not save whether you finished the comic or not.
+> For the best reading experience, it is recommended to store comics in the comic book archive or pdf format. This is due to issues when trying to read comics stored in the epub format. Please note, that Jellyfin 10.8 and later saves your reading position for comics in the comic book archive format, but does not save whether you finished the comic or not.
 
 ## Naming
 
@@ -47,4 +47,5 @@ The following metadata formats are supported:
 - ComicBookInfo (from ComicBookLover)
 
 > [!Note]
-> However, there are some limitations regarding the support of the ComicInfo format. `ComicInfo.xml` files can be parsed when they are placed in the same folder as the comic itself or when they are bundled within a `.cbz` file. `ComicInfo.xml` files bundled with any other archive format are not supported.
+> The ComicBookInfo format is supported when using the Bookshelf plugin version 8 or later.
+> The following limitations apply regarding the support of the ComicInfo format. `ComicInfo.xml` files can be parsed when they are placed in the same folder as the comic itself or when they are bundled within a `.cbz` file. `ComicInfo.xml` files bundled with any other archive format are not supported.

--- a/general/toc.yml
+++ b/general/toc.yml
@@ -38,6 +38,7 @@
   - name: Media
     items:
     - uid: server-media-books
+    - uid: server-media-comics
     - uid: server-media-internet-radio
     - uid: server-media-movies
     - uid: server-media-music


### PR DESCRIPTION
Adds the comic page to the table of contents and adds information about the required Jellyfin and Bookshelf plugin versions for specific parts of the documentation about comics.

- Saving the reading position ( jellyfin/jellyfin-web@14083377d1877a6a766b0a33e3f5c5db1c984b0e , jellyfin/jellyfin-web@51155004434555e5cc537e8e9e742c76a0271f03) is supported with Jellyfin-Web 10.8
- ComicBookInfo format (jellyfin/jellyfin-plugin-bookshelf@4b2c55d46876a1d753bf15ecd78e6ad261aa8fe6) is supported with the Bookshelf plugin version 8 and later.