### PR TITLE
nginx reverse proxy: allow bigger file upload ⬆️

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -30,6 +30,9 @@ server {
     # listen [::]:443 ssl http2;
     server_name DOMAIN_NAME;
 
+    ## The default `client_max_body_size` is 1M, so this might be not enaugh for some posters, etc.
+    client_max_body_size 20M;
+
     # use a variable to store the upstream proxy
     # in this example we are using a hostname which is resolved via DNS
     # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -30,7 +30,7 @@ server {
     # listen [::]:443 ssl http2;
     server_name DOMAIN_NAME;
 
-    ## The default `client_max_body_size` is 1M, so this might be not enaugh for some posters, etc.
+    ## The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
     client_max_body_size 20M;
 
     # use a variable to store the upstream proxy


### PR DESCRIPTION
default values is `client_max_body_size 1M`

Without setting this the user who uploads an image will see a loading circle without any error message.
Even the jellyfin logs are not useful. 

nginx error (logfile) is: client intended to send too large body