### PR TITLE
Fix broken hotio Dockerfile Link

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -19,7 +19,7 @@ hotio image: `hotio/jellyfin` <a href="https://hub.docker.com/r/hotio/jellyfin">
 Jellyfin distributes [official container images on Docker Hub](https://hub.docker.com/r/jellyfin/jellyfin/) for multiple architectures.
 These images are based on Debian and [built directly from the Jellyfin source code](https://github.com/jellyfin/jellyfin/blob/master/Dockerfile).
 
-Additionally the [LinuxServer.io](https://www.linuxserver.io/) project and [hotio](https://github.com/hotio) distribute images based on Ubuntu and the official Jellyfin Ubuntu binary packages, see [here](https://github.com/linuxserver/docker-jellyfin/blob/master/Dockerfile) and [here](https://github.com/hotio/docker-jellyfin/blob/stable/linux-amd64.Dockerfile) to see their Dockerfile.
+Additionally the [LinuxServer.io](https://www.linuxserver.io/) project and [hotio](https://github.com/hotio) distribute images based on Ubuntu and the official Jellyfin Ubuntu binary packages, see [here](https://github.com/linuxserver/docker-jellyfin/blob/master/Dockerfile) and [here](https://github.com/hotio/jellyfin/blob/release/linux-amd64.Dockerfile) to see their Dockerfile.
 
 > [!Note]
 > For ARM hardware and RPi, it is recommended to use the LinuxServer.io or hotio image since hardware acceleration support is not yet available on the native image.


### PR DESCRIPTION
The [installing](https://jellyfin.org/docs/general/administration/installing.html) page includes a link directly to the raw Dockerfiles used by LinuxServer.io and hotio.  The link to the hotio file on Github is broken because they have reorganized the repository.

This PR fixes that link.