### PR TITLE
Created an Addons section

### DIFF
--- a/general/server/plugins/addons.md
+++ b/general/server/plugins/addons.md
@@ -1,0 +1,85 @@
+---
+uid: server-plugins-Addons
+title: Addons
+---
+
+
+### ErsatzTV
+
+#### Description
+ErsatzTV is an amazing Jellyfin addon that is a great way to take your Jellyfin libraries and make them into Live TV Channels. For example if i wanted to link All episodes of Trailer Park Boys and shuffle them at random like you were watching it on live tv this plugins can do it. Not only that but you can make custom channel names, Logos, Watermarks transcodings and add Movies, TV-Shows, and Music Collections of all sorts. This is a must if you want a cable like experience without paying or having buggy iptv interfaces.
+
+**Link:**
+
+* [Github](https://github.com/jasongdove/ErsatzTV)
+
+### JF-Secure
+
+#### Description
+A turn key Caddy Reverse Proxy Webserver setup for Jellyfin without any codiung required.
+
+**NOTE: THIS IS WINDOWS ONLY**
+
+**Link:**
+
+* [Github](https://github.com/dab2020/JF-secure)
+* [Latest Release](https://github.com/dab2020/JF-secure/releases)
+
+### Jellyfin_HA
+
+#### Description
+For All you smart home Jellyfin users Jellyfin HA is a good way to monitor start and start and configure your media server from Home Assistant.
+
+**Link:**
+
+* [Github](https://github.com/koying/jellyfin_ha)
+* [Latest Release](https://github.com/koying/jellyfin_ha/releases)
+
+### Jellyfin Party Extensions
+
+#### Description
+Have you ever wanted to have all your friends watch a movie or tv show together without having to give them accss to the Jelyfin UI. Well here it is. Just pull up a chrome make a link start the movie and stream with all your friends through your chrome browser to theirs.
+
+**Links:**
+
+* [GitHub](https://github.com/Jelly-Party/jelly-party-extension)
+* [Jellyfin Chrome Extensions Install](https://www.jelly-party.com/)
+
+### Jellyfin Helm
+
+#### Description
+For all you chart trackers and multiple web app users. This is a way to add all your jellyfin stats to your helm web app.
+
+* [Github](https://github.com/brianmcarey/jellyfin-helm)
+
+
+### JFA-Go
+
+#### Description
+Have you wanted your users to be able to remotely reset their password without you having to do it. Well JFA-Go is it. All you have to do is set it up, link your jellyfin install, and profit. This not only lets users reset their password, but you can add new accounts set a static layout for the main pages libraries on all users from a dummy account with permissions. 
+
+**Links:**
+
+* [GitHub](https://github.com/hrfee/jfa-go)
+* [Latest Release](https://github.com/hrfee/jfa-go/releases)
+
+### TV Intro Detection
+
+#### Description
+This is a way to skip all your TV Show introductions like netflix does. Unfortuntly it does not do outros yet, but its a great start.
+
+**NOTE: DOCKER ONLY**
+
+**Links:**
+
+* [GitHub](https://github.com/jellyfin/jellyfin-plugin-emailnotifications)
+* [Documentation](https://mueslimak3r.github.io/tv-intro-detection/)
+
+### Emby2Jelly
+
+#### Description
+This is a good way to move jellyfin from one server to another host of jellyfin, or move from Emby to Jellyfin without losing data metadata critical data.
+
+**Links:**
+
+* [GitHub](https://github.com/Marc-Vieg/Emby2Jelly)


### PR DESCRIPTION
I originally added a github repo stars in plugins. I decided to add an addons repo with all the possible addons not already listed in jellyfins docs. I figured this was best since it didnt fit any of the other categories and to make it simpler for people to find what they want in the least amount of clicks.