### PR TITLE
Disable publish workflow on forks

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ on:
 jobs:
   build_publish:
     uses: ./.github/workflows/_meta.yaml
+    if: ${{ github.repository == 'jellyfin/jellyfin-docs' }}
     with:
       publish: true
     secrets:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_publish:
     uses: ./.github/workflows/_meta.yaml
-    if: ${{ github.repository == 'jellyfin/jellyfin-docs' }}
+    if: ${{ contains(github.repository_owner, 'jellyfin') }}
     with:
       publish: true
     secrets:


### PR DESCRIPTION
The workflow fails on forks (missing the token) and doesn't make sense anyway.