### PR TITLE
Update nginx.md - Improve Video Caching Doc

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -205,12 +205,12 @@ map $request_uri $h264Level { ~(h264-level=)(.+?)& $2; }
 map $request_uri $h264Profile { ~(h264-profile=)(.+?)& $2; }
 
 # Set in Server block
-location ~* ^/Videos/
+location ~* ^/Videos/(.*)/(?!live)
 {
   # Set size of a slice (this amount will be always requested from the backend by nginx)
   # Higher value means more latency, lower more overhead
   # This size is independent of the size clients/browsers can request
-  slice 10m;
+  slice 2m;
 
   proxy_cache jellyfin-videos;
   proxy_cache_valid 200 206 301 302 30d;

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -198,26 +198,42 @@ access_log /var/log/nginx/access.log stripsecrets;
 ### Cache Video Streams
 
 ```conf
-#Must be in HTTP block
-proxy_cache_path  /home/cache/web levels=1:2 keys_zone=cWEB:50m inactive=90d max_size=35000m;
+# Must be in HTTP block
+# Set in-memory cache-metadata size in keys_zone, size of video caching and how many days a cached object should persist
+proxy_cache_path  /var/cache/nginx/jellyfin-videos levels=1:2 keys_zone=jellyfin-videos:100m inactive=90d max_size=35000m;
 map $request_uri $h264Level { ~(h264-level=)(.+?)& $2; }
 map $request_uri $h264Profile { ~(h264-profile=)(.+?)& $2; }
 
-#set in Server block
-proxy_cache cWEB;
-proxy_cache_valid 200 301 302 30d;
-proxy_ignore_headers Expires Cache-Control Set-Cookie X-Accel-Expires;
-proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-proxy_connect_timeout 10s;
-proxy_http_version 1.1;
-proxy_set_header Connection "";
+# Set in Server block
+location ~* ^/Videos/
+{
+  # Set size of a slice (this amount will be always requested from the backend by nginx)
+  # Higher value means more latency, lower more overhead
+  # This size is independent of the size clients/browsers can request
+  slice 10m;
 
-location /videos/
-  {
-  proxy_pass http://myJF-IP:8096;
-  proxy_cache_key "mydomain.com$uri?MediaSourceId=$arg_MediaSourceId&VideoCodec=$arg_VideoCodec&AudioCodec=$arg_AudioCodec&AudioStreamIndex=$arg_AudioStreamIndex&VideoBitrate=$arg_VideoBitrate&AudioBitrate=$arg_AudioBitrate&SubtitleMethod=$arg_SubtitleMethod&TranscodingMaxAudioChannels=$arg_TranscodingMaxAudioChannels&RequireAvc=$arg_RequireAvc&SegmentContainer=$arg_SegmentContainer&MinSegments=$arg_MinSegments&BreakOnNonKeyFrames=$arg_BreakOnNonKeyFrames&h264-profile=$h264Profile&h264-level=$h264Level";
-  proxy_cache_valid 200 301 302 30d;
-  }
+  proxy_cache jellyfin-videos;
+  proxy_cache_valid 200 206 301 302 30d;
+  proxy_ignore_headers Expires Cache-Control Set-Cookie X-Accel-Expires;
+  proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+  proxy_connect_timeout 15s;
+  proxy_http_version 1.1;
+  proxy_set_header Connection "";
+  # Transmit slice range to the backend
+  proxy_set_header Range $slice_range;
+
+  # This saves bandwidth between the proxy and jellyfin, as a file is only downloaded one time instead of multiple times when multiple clients want to at the same time
+  # The first client will trigger the download, the other clients will have to wait until the slice is cached
+  # Esp. practical during SyncPlay
+  proxy_cache_lock on;
+  proxy_cache_lock_age 60s;
+
+  proxy_pass http://$jellyfin:8096;
+  proxy_cache_key "jellyvideo$uri?MediaSourceId=$arg_MediaSourceId&VideoCodec=$arg_VideoCodec&AudioCodec=$arg_AudioCodec&AudioStreamIndex=$arg_AudioStreamIndex&VideoBitrate=$arg_VideoBitrate&AudioBitrate=$arg_AudioBitrate&SubtitleMethod=$arg_SubtitleMethod&TranscodingMaxAudioChannels=$arg_TranscodingMaxAudioChannels&RequireAvc=$arg_RequireAvc&SegmentContainer=$arg_SegmentContainer&MinSegments=$arg_MinSegments&BreakOnNonKeyFrames=$arg_BreakOnNonKeyFrames&h264-profile=$h264Profile&h264-level=$h264Level&slicerange=$slice_range";
+  
+  # add_header X-Cache-Status $upstream_cache_status; # This is only for debugging cache
+
+}
 ```
 
 ### Cache Images


### PR DESCRIPTION
### Improvement of Video Caching

With the old configuration, only transcoded files could be cached - but not direct streamed one.

For some reason transcoded files use the lowercase /video, while direct-streamed files use /Video
This behaviour is inconsistent with the API definitions: https://api.jellyfin.org/#operation/GetVideoStream
However both clearly use the same API-Endpoint

Example for a request with a direct stream without transcoding:
```
/Videos/64b9cbabd59eb39b97e3cfa012d66f37/stream.mp4?Static=true&mediaSourceId=af566d16ac11a232da0c8d915b1654a6&deviceId=TW96aWxsYS81LjAgKE1hY2ludG9zaDsgSW50ZWwgTWFjIE9TIFggMTBfMTVfNykgQXBwbGVXZWJLaXQvNjA1LjEuMTUgKEtIVE1MLCBsaWtlIEdlY2tvKSBWZXJzaW9uLzE1LjUgU2FmYXJpLzYwNS4xLjE1fDE2NTY4NTA3NjkyNTk1&api_key=...&Tag=93aef1b3d97e5c203f71887814f999ec
```

Exampled for a request with transcoding:
```
/videos/33ccdfc3-6917-60d9-7dc3-e44014f6ffb4/hls1/main/758.ts?DeviceId=TW96aWxsYS81LjAgKE1hY2ludG9zaDsgSW50ZWwgTWFjIE9TIFggMTBfMTVfNykgQXBwbGVXZWJLaXQvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hyb21lLzEwMy4wLjAuMCBTYWZhcmkvNTM3LjM2fDE2NTY4NDI3NDM3NjY1&MediaSourceId=33ccdfc3691760d97dc3e44014f6ffb4&VideoCodec=h264&AudioCodec=aac,mp3&AudioStreamIndex=3&VideoBitrate=59872000&AudioBitrate=128000&MaxFramerate=25&PlaySessionId=b95c1ddd75bc4f4e8c5f18cfb5b77aa4&api_key=...&TranscodingMaxAudioChannels=2&RequireAvc=false&Tag=51635412177361ee7086c7c96d554456&SegmentContainer=ts&MinSegments=2&BreakOnNonKeyFrames=True&mpeg4-level=5&mpeg4-videobitdepth=8&mpeg4-profile=advancedsimpleprofile&h264-profile=high,main,baseline,constrainedbaseline,high10&h264-rangetype=SDR&h264-level=52&h264-deinterlace=true&TranscodeReasons=VideoCodecNotSupported&runtimeTicks=22740000000&actualSegmentLengthTicks=30000000
```

Also to permit direct-streaming I use slicing. That means that NGINX will slice the file according to the parameter X (e.g. 10 megabytes). When the client requests a mp4 in range 18mb-22mb nginx will download the two slices from 10-20, and 20-30 cache them as files, and of those transmit exactly 18-22 to the client. Subsequent requests will be directly streamed from the cache.
Video caching of (larger) files cannot work without slicing. Without slicing it is only possible for transcoded files, as jellyfin will slice them by itself in small .ts files.

Here is a great article about the details:
https://blog.fearcat.in/a?ID=00900-9c4500ae-58b4-41c6-bab6-edb91795d466

Also I used the parameter `proxy_cache_lock`. That means, when two clients watch something at the same time, both with e.g. 20mbit/s; then nginx will make sure that the backend will be only contacted once for that slice and the other request will be served directly from cache. So instead of using 2*20mbit/s bandwidth of the backend, it will only use 20 mbit/s

What I changed exactly:
- Make /Video path case insensitive (as Jellyfin uses upper and lower case)
- Clean the configuration up, by moving the proxy parameters inside the location block
- Made the configuration more consistent with the base configuration, e.g. by using the variable $jellyfin
- Slicing
    - Added the slicing parameter
    - Added status code 206 to the cached requests - which is required
    - Pass the range $slice_range to the backend
    - Add $slice_range as key, so it can be properly cached