### PR TITLE
Add nginx HTTPS example config for subpath method

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -114,6 +114,7 @@ When connecting to server from a client application, enter `http(s)://DOMAIN_NAM
 Set the [base URL](xref:network-index#base-url) field in the Jellyfin server.  This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client.  Fill in this box with `/jellyfin` and click Save.  The server will need to be restarted before this change takes effect.
 
 ### HTTP config example
+
 > [!WARNING]
 > HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
 

--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -113,11 +113,12 @@ When connecting to server from a client application, enter `http(s)://DOMAIN_NAM
 
 Set the [base URL](xref:network-index#base-url) field in the Jellyfin server.  This can be done by navigating to the Admin Dashboard -> Networking -> Base URL in the web client.  Fill in this box with `/jellyfin` and click Save.  The server will need to be restarted before this change takes effect.
 
+### HTTP config example
 > [!WARNING]
-> HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS. [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
+> HTTP is insecure. The following configuration is provided for ease of use only. If you are planning on exposing your server over the Internet you should setup HTTPS (see below for HTTPS configuration example). [Let's Encrypt](https://letsencrypt.org/getting-started/) can provide free TLS certificates which can be installed easily via [certbot](https://certbot.eff.org/).
 
 ```conf
-# Jellyfin hosted on http(s)://DOMAIN_NAME/jellyfin
+# Jellyfin hosted on http://DOMAIN_NAME/jellyfin
 
 server {
     listen 80;
@@ -169,6 +170,75 @@ server {
         # Disable buffering when the nginx proxy gets very resource heavy upon streaming
         proxy_buffering off;
     }
+}
+```
+
+### HTTPS config example
+
+The following config is meant to work with Certbot / Let's Encrypt.
+
+```conf
+# Jellyfin hosted on https://DOMAIN_NAME/jellyfin
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name DOMAIN_NAME;
+
+    # Uncomment to redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name DOMAIN_NAME;
+    # You can specify multiple domain names if you want
+    #server_name jellyfin.local;
+    ssl_certificate /etc/letsencrypt/live/DOMAIN_NAME/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/DOMAIN_NAME/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    ssl_trusted_certificate /etc/letsencrypt/live/DOMAIN_NAME/chain.pem;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    # use a variable to store the upstream proxy
+    # in this example we are using a hostname which is resolved via DNS
+    # (if you aren't using DNS remove the resolver line and change the variable to point to an IP address e.g `set $jellyfin 127.0.0.1`)
+    set $jellyfin jellyfin;
+    resolver 127.0.0.1 valid=30;
+
+    # Jellyfin
+    location /jellyfin {
+        return 302 $scheme://$host/jellyfin/;
+    }
+
+    location /jellyfin/ {
+        # Proxy main Jellyfin traffic
+
+        # The / at the end is significant.
+        # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
+
+        proxy_pass http://$jellyfin:8096;
+
+        proxy_pass_request_headers on;
+
+        proxy_set_header Host $host;
+
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+
+        # Disable buffering when the nginx proxy gets very resource heavy upon streaming
+        proxy_buffering off;
+    }
+
 }
 ```
 


### PR DESCRIPTION
The existing nginx config for the subpath method doesn't include the necessary elements to use HTTPS (contrary to the subdomain one).
In addition to the new server entry, the `proxy_pass` value is updated to remove the `/jellyfin/` suffix which creates an infinite redirect loop (as explained in https://www.reddit.com/r/jellyfin/comments/duhwjd/nginx_infinite_redirect_loop_after_upgrading_to/)