### PR TITLE
Correct queries for unlocking user accounts

### DIFF
--- a/general/administration/troubleshooting.md
+++ b/general/administration/troubleshooting.md
@@ -102,7 +102,7 @@ sqlite3 /PATH/TO/JELLYFIN/DB/jellyfin.db
 
 ```sql
 UPDATE Users SET InvalidLoginAttemptCount = 0 WHERE Username = 'LockedUserName';
-update Permissions set Value = 0 where Kind = 2 and Permission_Permissions_Guid in (select Id from Users where Username = 'LockedUserName');
+UPDATE Permissions SET Value = 0 WHERE Kind = 2 AND UserId IN (SELECT Id FROM Users WHERE Username = 'LockedUserName');
 .exit
 ```
 
@@ -114,5 +114,5 @@ After opening the database, navigate to the Execute SQL Tab and execute the foll
 
 ```sql
 UPDATE Users SET InvalidLoginAttemptCount = 0 WHERE Username = 'LockedUserName';
-update Permissions set Value = 0 where Kind = 2 and Permission_Permissions_Guid in (select Id from Users where Username = 'LockedUserName');
+UPDATE Permissions SET Value = 0 WHERE Kind = 2 AND UserId IN (SELECT Id FROM Users WHERE Username = 'LockedUserName');
 ```


### PR DESCRIPTION
The queries for editing the Permissions table were trying to match GUIDs against User IDs. This fixes the queries to correctly line up the Permissions table's Foreign Key `UserId` against the Users table's `Id`. It also makes the query style consistent as that bugged me a bit. :slightly_smiling_face: 