### PR TITLE
Patch 1

### DIFF
--- a/general/administration/install/synology.md
+++ b/general/administration/install/synology.md
@@ -32,3 +32,10 @@ Host Mode is required for HdHR and DLNA. Use bridge mode if running multiple ins
 ![Installing Synology](~/images/install-synology-9.png)
 
 Browse to `http://SERVER_IP:8096` to access the web client.
+
+**Note on Hardware Acceleration **
+
+If you want to use Hardware Acceleration, check the "Execute container using high privledge" box either during container setup, or after, when the container is stopped, but using the "edit" button in the Docker interface:
+![image](https://user-images.githubusercontent.com/19777571/190295042-76d9997b-f9f9-4135-ae0d-18d368418bed.png)
+
+

--- a/general/administration/install/synology.md
+++ b/general/administration/install/synology.md
@@ -37,5 +37,3 @@ Browse to `http://SERVER_IP:8096` to access the web client.
 
 If you want to use Hardware Acceleration, check the "Execute container using high privledge" box either during container setup, or after, when the container is stopped, but using the "edit" button in the Docker interface:
 ![image](https://user-images.githubusercontent.com/19777571/190295042-76d9997b-f9f9-4135-ae0d-18d368418bed.png)
-
-


### PR DESCRIPTION
Added detail about the "sledgehammer way" to reliably enable hardware acceleration for Docker on Synology.  If I figure out a better non-sledgehammer way that's more elegant, i'll update the docs.