### PR TITLE
Keep HTTPS request headers

### DIFF
--- a/general/networking/apache.md
+++ b/general/networking/apache.md
@@ -31,6 +31,10 @@ title: Apache
     # Letsencrypt's certbot will place a file in this folder when updating/verifying certs
     # This line will tell apache to not to use the proxy for this folder.
     ProxyPass "/.well-known/" "!"
+    
+    # Tell Jellyfin to forward that requests came from TLS connections
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
 
     ProxyPass "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"
     ProxyPassReverse "/socket" "ws://SERVER_IP_ADDRESS:8096/socket"


### PR DESCRIPTION
https://github.com/9p4/jellyfin-plugin-sso/issues/79 fixes the above bug