### PR TITLE
Fix failregex for fail2ban config

### DIFF
--- a/general/networking/fail2ban.md
+++ b/general/networking/fail2ban.md
@@ -65,7 +65,7 @@ And add this to the new file:
 
 ```bash
 [Definition]
-failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
+failregex = ^.*Authentication request for .* has been denied \(IP: <ADDR>\)\.
 ```
 
 Save and exit, then reload Fail2ban:

--- a/general/networking/fail2ban.md
+++ b/general/networking/fail2ban.md
@@ -65,7 +65,7 @@ And add this to the new file:
 
 ```bash
 [Definition]
-failregex = ^.*Authentication request for ".*" has been denied \(IP: "<ADDR>"\)\.
+failregex = ^.*Authentication request for .* has been denied \(IP: "<ADDR>"\)\.
 ```
 
 Save and exit, then reload Fail2ban:


### PR DESCRIPTION
The user name is no longer surrounded by "


It seems that the log format for failed login attempts has changed. For example:

`Oct 03 17:41:05 manjaro-server docker_jellyfin[461]: [16:41:05] [INF] [79] Jellyfin.Server.Implementations.Users.UserManager: Authentication request for arsasrtarstartarstars has been denied (IP: 172.16.53.2).`

The user name is no longer surrounded by a quotation marks.