### PR TITLE
Add documentation for EmbeddedImageExtractor

### DIFF
--- a/general/server/media/movies.md
+++ b/general/server/media/movies.md
@@ -160,6 +160,8 @@ Movies
 
 ## Images
 
+The following files may also be embedded into video containers that support it (such as mkv) and will be read out by the `Embedded Image Extractor` if enabled as an `Image Extractor` on the library configuration page.
+
 ### Poster
 
 * folder.ext

--- a/general/server/media/shows.md
+++ b/general/server/media/shows.md
@@ -46,6 +46,8 @@ Show extras, sometimes called specials, can be added in the `Season 00` folder. 
 
 ## Images
 
+Posters, Backdrops, and Logos may also be embedded into video containers that support it (such as mkv) and will be read out by the `Embedded Image Extractor` if enabled as an `Image Extractor` on the library configuration page.
+
 ### Poster
 
 * folder.ext


### PR DESCRIPTION
The `Embedded Image Extractor` was added in 10.8 to allow embedding different types of images into video containers that support it. I was moving when 10.8 was released and forgot to update the documentation.