### PR TITLE
Expand external file flag documentation

### DIFF
--- a/general/server/media/external-files.md
+++ b/general/server/media/external-files.md
@@ -46,7 +46,7 @@ Additional flags can be appended to the filename (separated by the `.` delimiter
   * Indicates that the subtitle stream has additional information to help viewers that are hearing impaired.
 
 > [!Note]
-> `hi` collides with the Hindi language abbreviation. `hi` by itself with resolve as a Hindi-language track, while `hi` in conjunction with another language identifier (such as `title.en.hi.srt`) will use the other language and tag it as hearing impaired.
+> `hi` collides with the Hindi language abbreviation. `hi` by itself will resolve as a Hindi language track, while `hi` in conjunction with another language identifier (such as `title.en.hi.srt`) will use the other language and tag it as hearing impaired.
 
 Flags are ignored on containers with more than one stream.
 

--- a/general/server/media/external-files.md
+++ b/general/server/media/external-files.md
@@ -44,7 +44,9 @@ Additional flags can be appended to the filename (separated by the `.` delimiter
   * Marks the subtitle stream as forced, typically used for translation of segments of audio/text that differ from the primary language.
 * Hearing Impaired (Jellyfin 10.9+): `sdh`, `cc`, `hi`
   * Indicates that the subtitle stream has additional information to help viewers that are hearing impaired.
-  * Note that `hi` collides with the Hindi language abbreviation. `hi` by itself with resolve as a Hindi-language track, while `hi` in conjunction with another language identifier (such as `title.en.hi.srt`) will use the other language and tag it as hearing impaired.
+
+> [!Note]
+> `hi` collides with the Hindi language abbreviation. `hi` by itself with resolve as a Hindi-language track, while `hi` in conjunction with another language identifier (such as `title.en.hi.srt`) will use the other language and tag it as hearing impaired.
 
 Flags are ignored on containers with more than one stream.
 

--- a/general/server/media/external-files.md
+++ b/general/server/media/external-files.md
@@ -15,12 +15,8 @@ The server supports reading either single files or containers like mka (Matroska
 
 Jellyfin will search for external files that exactly match the video filename.
 They can optionally include a language which will only be used if the language cannot be determined from the file metadata.
-They can also include the `forced` (or `foreign`) and `default` flags to mark the streams accordingly.
-Those flags are ignored on containers with more than one stream.
-Flags and language need to be appended to the video filename with `.` as delimiter.
 
 If multiple languages are defined within the filename the last one will be used and the others ignored.
-Any arbitrary text not parsable to a language or flag will be combined and used as the title of the stream.
 
 ### Simple example
 
@@ -30,23 +26,40 @@ Any arbitrary text not parsable to a language or flag will be combined and used 
         Film.mkv
         Film.vtt
         Film.aac
+        Film.mka
+        Film.mks
+        Film.en.ac3
         Film.de.srt
         Film.en.dts
         Film.german.ac3
 ```
 
-## Extended example with flags and stream title
+### Naming Flags
+
+Additional flags can be appended to the filename (separated by the `.` delimiter) to add metadata. Supported metadata and flags are:
+
+* Default: `default`
+  * Marks the stream as the default.
+* Forced: `forced`, `foreign`
+  * Marks the subtitle stream as forced, typically used for translation of segments of audio/text that differ from the primary language.
+* Hearing Impaired (Jellyfin 10.9+): `sdh`, `cc`, `hi`
+  * Indicates that the subtitle stream has additional information to help viewers that are hearing impaired.
+  * Note that `hi` collides with the Hindi language abbreviation. `hi` by itself with resolve as a Hindi-language track, while `hi` in conjunction with another language identifier (such as `title.en.hi.srt`) will use the other language and tag it as hearing impaired.
+
+Flags are ignored on containers with more than one stream.
+
+Any arbitrary text not parsable to a language or flag will be combined and used as the title of the stream (if there is not a stream title already embedded in the file metadata).
+
+### Extended example with flags and stream title
 
 ```txt
 /Movies
     /Film (1986)
         Film.mkv
-        Film.mka
-        Film.mks
-        Film.en.ac3
         Film.default.srt
         Film.default.en.forced.ass
-        Film.forced.forced.en.dts
+        Film.forced.en.dts
+        Film.en.sdh.srt
         Film.English Commentary.en.mp3
 ```
 


### PR DESCRIPTION
Adds "Hearing Impaired" and restructures the section on flags in external file naming now that we're at 3 types of supported flags.

Until a better path is decided on (doc versioning?) I left a note on the hearing impaired line to indicate that it will be in next release.