### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 <h1 align="center">Jellyfin Documentation</h1>
 <h3 align="center">Part of the <a href="https://jellyfin.media">Jellyfin Project</a></h3>
 
+**This repository has been deprecated. Please use [the jellyfin.org repository instead](https://github.com/jellyfin/jellyfin.org).**
+
 This repository houses all documentation for Jellyfin available at [jellyfin.org](https://docs.jellyfin.org/) and written in markdown.
 
 ## Getting Started


### PR DESCRIPTION
Don't merge until https://github.com/jellyfin/jellyfin.org/pull/226 is live, and archive immediately afterwards.