### PR TITLE
Remove note about RPi and non-official images

### DIFF
--- a/general/administration/installing.md
+++ b/general/administration/installing.md
@@ -21,9 +21,6 @@ These images are based on Debian and [built directly from the Jellyfin source co
 
 Additionally the [LinuxServer.io](https://www.linuxserver.io/) project and [hotio](https://github.com/hotio) distribute images based on Ubuntu and the official Jellyfin Ubuntu binary packages, see [here](https://github.com/linuxserver/docker-jellyfin/blob/master/Dockerfile) and [here](https://github.com/hotio/jellyfin/blob/release/linux-amd64.Dockerfile) to see their Dockerfile.
 
-> [!Note]
-> For ARM hardware and RPi, it is recommended to use the LinuxServer.io or hotio image since hardware acceleration support is not yet available on the native image.
-
 ### Docker
 
 [Docker](https://www.docker.com/) allows you to run containers on Linux, Windows and MacOS.


### PR DESCRIPTION
On the latest version of Raspberry Pi OS / Raspbian on a RPi 4, I'm able to use rootless Podman + crun to run jellyfin with the official image and get hardware accelerated encoding, so it seems like this note is out of date. The linuxserver image has apparently [switched](https://github.com/linuxserver/docker-jellyfin#versions) to using the official build's ffmpeg5, so the differences between the two images may be much smaller nowadays.

I'm using this command to run jellyfin after `sudo apt install podman crun`:

```sh
podman run \
 --detach \           
 --label "io.containers.autoupdate=image" \
 --name jellyfin \
 --publish 8096:8096/tcp \
 --rm \
 --user $(id -u):$(id -g) \
 --userns keep-id \
 --mount type=bind,source=/mnt/media/jellyfin/cache,destination=/cache \
 --mount type=bind,source=/mnt/media/jellyfin/config,destination=/config \
 --mount type=bind,source=/mnt/media/video/new,destination=/media,ro=true
 --device=/dev/video10 \
 --device=/dev/video11 \
 --device=/dev/video12 \
 --annotation run.oci.keep_original_groups=1 --runtime /usr/bin/crun \
 docker.io/jellyfin/jellyfin:latest
```

The second to last line is so that I can access the video devices in the container, since I can only access to them via a secondary (`video`) group by my regular user.
On more recent versions of podman, that line may be replacable by `--group-add keep-groups`.

Proof it's working from the logs:
```
Stream mapping:
  Stream #0:0 -> #0:0 (mpeg4 (native) -> h264 (h264_v4l2m2m))
  Stream #0:1 -> #0:1 (ac3 (native) -> aac (libfdk_aac))
Press [q] to stop, [?] for help
[mpeg4 @ 0x39ed320] Video uses a non-standard and wasteful way to store B-frames ('packed B-frames'). Consider using the mpeg4_unpack_bframes bitstream filter without encoding but stream copy to fix it.
[h264_v4l2m2m @ 0x39eb170] Using device /dev/video11
[h264_v4l2m2m @ 0x39eb170] driver 'bcm2835-codec' on card 'bcm2835-codec-encode' in mplane mode
[h264_v4l2m2m @ 0x39eb170] requesting formats: output=YU12 capture=H264
[h264_v4l2m2m @ 0x39eb170] Failed to set gop size: Invalid argument
Output #0, hls, to '/config/transcodes/1e167a448cdf1d87a7394db717462369.m3u8':
  Metadata:
    encoder         : Lavf59.27.100
  Stream #0:0: Video: h264, yuv420p(bt709, progressive), 1280x544 [SAR 1:1 DAR 40:17], q=2-31, 4471 kb/s, 25 fps, 90k tbn
    Metadata:
      encoder         : Lavc59.37.100 h264_v4l2m2m
  Stream #0:1: Audio: aac, 48000 Hz, stereo, s16, 384 kb/s
    Metadata:
      encoder         : Lavc59.37.100 libfdk_aac
frame=    1 fps=0.0 q=0.0 size=N/A time=00:00:00.00 bitrate=N/A speed=   0x    
frame=   65 fps=0.0 q=-0.0 size=N/A time=00:00:02.56 bitrate=N/A speed=4.42x    
[hls @ 0x39ea580] Opening '/config/transcodes/1e167a448cdf1d87a7394db7174623690.ts' for writing
frame=  132 fps=122 q=-0.0 size=N/A time=00:00:05.29 bitrate=N/A speed= 4.9x    

```